### PR TITLE
Some minor tidying and adding bidiagonal decomposition

### DIFF
--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -331,7 +331,22 @@ impl<T: Any + Float + Signed> Matrix<T> {
     /// Converts matrix to bidiagonal form
     ///
     /// Returns (B, U, V), where B is bidiagonal and `self = U B V_T`.
+    ///
+    /// Note that if `self` has `self.rows() > self.cols()` the matrix will
+    /// be transposed and then reduced - this will lead to a sub-diagonal instead
+    /// of super-diagonal.
+    ///
+    /// # Failures
+    ///
+    /// - The matrix cannot be reduced to bidiagonal form.
     pub fn bidiagonal_decomp(mut self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
+        let mut flipped = false;
+        
+        if self.rows < self.cols {
+            flipped = true;
+            self = self.transpose()
+        }
+
         let m = self.rows;
         let n = self.cols;
 
@@ -339,28 +354,25 @@ impl<T: Any + Float + Signed> Matrix<T> {
         let mut v = Matrix::identity(n);
 
         for k in 0..n {
-            if k < m {
-                let h_holder: Matrix<T>;
-                {
-                    let lower_slice = MatrixSlice::from_matrix(&self, [k, k], m - k, 1);
-                    h_holder = try!(Matrix::make_householder(&lower_slice.iter()
-                            .cloned()
-                            .collect::<Vec<_>>())
-                        .map_err(|_| {
-                            Error::new(ErrorKind::DecompFailure, "Cannot compute bidiagonal form.")
-                        }));
-                }
+            let h_holder: Matrix<T>;
+            {
+                let lower_slice = MatrixSlice::from_matrix(&self, [k, k], m - k, 1);
+                h_holder = try!(Matrix::make_householder(&lower_slice.iter()
+                        .cloned()
+                        .collect::<Vec<_>>())
+                    .map_err(|_| {
+                        Error::new(ErrorKind::DecompFailure, "Cannot compute bidiagonal form.")
+                    }));
+            }
 
-                {
-                    // Apply householder on the left to kill under diag.
-                    let lower_self_block =
-                        MatrixSliceMut::from_matrix(&mut self, [k, k], m - k, n - k);
-                    let transformed_self = &h_holder * &lower_self_block;
-                    lower_self_block.set_to(transformed_self.as_slice());
-                    let lower_u_block = MatrixSliceMut::from_matrix(&mut u, [0, k], m, m - k);
-                    let transformed_u = &lower_u_block * h_holder;
-                    lower_u_block.set_to(transformed_u.as_slice());
-                }
+            {
+                // Apply householder on the left to kill under diag.
+                let lower_self_block = MatrixSliceMut::from_matrix(&mut self, [k, k], m - k, n - k);
+                let transformed_self = &h_holder * &lower_self_block;
+                lower_self_block.set_to(transformed_self.as_slice());
+                let lower_u_block = MatrixSliceMut::from_matrix(&mut u, [0, k], m, m - k);
+                let transformed_u = &lower_u_block * h_holder;
+                lower_u_block.set_to(transformed_u.as_slice());
             }
 
             if k < n - 2 {
@@ -393,7 +405,17 @@ impl<T: Any + Float + Signed> Matrix<T> {
             }
         }
 
-        Ok((self, u, v))
+        // Trim off the zerod blocks.
+        self.data.truncate(n * n);
+        self.rows = n;
+        u = MatrixSlice::from_matrix(&u, [0,0], m, n).into_matrix();
+
+        if flipped {
+            Ok((self.transpose(), v, u))
+        } else {
+            Ok((self, u, v))
+        }
+        
     }
 
     fn balance_matrix(&mut self) {
@@ -849,10 +871,11 @@ mod tests {
     use matrix::Matrix;
     use vector::Vector;
 
-    fn validate_bidiag(mat: &Matrix<f64>, b: &Matrix<f64>, u: &Matrix<f64>, v: &Matrix<f64>) {
+    fn validate_bidiag(mat: &Matrix<f64>, b: &Matrix<f64>, u: &Matrix<f64>, v: &Matrix<f64>, upper: bool) {
         for (idx, row) in b.iter_rows().enumerate() {
-            assert!(!row.iter().take(idx).any(|&x| x > 1e-10));
-            assert!(!row.iter().skip(idx + 2).any(|&x| x > 1e-10));
+            let pair_start = if upper { idx } else { idx.saturating_sub(1) };
+            assert!(!row.iter().take(pair_start).any(|&x| x > 1e-10));
+            assert!(!row.iter().skip(pair_start + 2).any(|&x| x > 1e-10));
         }
 
         let recovered = u * b * v.transpose();
@@ -874,7 +897,7 @@ mod tests {
                                    7.0, 1.0, 1.0, 4.0, 2.0, 1.0, -1.0, 3.0, 5.0, 1.0, 1.0, 3.0,
                                    2.0]);
         let (b, u, v) = mat.clone().bidiagonal_decomp().unwrap();
-        validate_bidiag(&mat, &b, &u, &v);
+        validate_bidiag(&mat, &b, &u, &v, true);
     }
 
     #[test]
@@ -884,14 +907,14 @@ mod tests {
                               vec![1f64, 2.0, 3.0, 4.0, 5.0, 2.0, 4.0, 1.0, 2.0, 1.0, 3.0, 1.0,
                                    7.0, 1.0, 1.0]);
         let (b, u, v) = mat.clone().bidiagonal_decomp().unwrap();
-        validate_bidiag(&mat, &b, &u, &v);
+        validate_bidiag(&mat, &b, &u, &v, true);
 
         let mat = Matrix::new(3,
                               5,
                               vec![1f64, 2.0, 3.0, 4.0, 5.0, 2.0, 4.0, 1.0, 2.0, 1.0, 3.0, 1.0,
                                    7.0, 1.0, 1.0]);
         let (b, u, v) = mat.clone().bidiagonal_decomp().unwrap();
-        validate_bidiag(&mat, &b, &u, &v);
+        validate_bidiag(&mat, &b, &u, &v, false);
     }
 
     #[test]

--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -285,10 +285,10 @@ impl<T: Any + Float + Signed> Matrix<T> {
     /// let a = Matrix::new(3,3,vec![1.,2.,3.,4.,5.,6.,7.,8.,9.]);
     ///
     /// // u is the transform, h is the upper hessenberg form.
-    /// let (u,h) = a.upper_hess_decomp().expect("This matrix should decompose!");
+    /// let (u,h) = a.clone().upper_hess_decomp().expect("This matrix should decompose!");
     ///
     /// println!("The hess : {:?}", h.data());
-    /// println!("Manual hess : {:?}", (u.transpose() * &a * u).data());
+    /// println!("Manual hess : {:?}", (u.transpose() * a * u).data());
     /// ```
     ///
     /// # Panics

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -133,7 +133,7 @@ impl<T> Matrix<T> {
     }
 
     /// Get a mutable reference to a point in the matrix without bounds checks.
-    pub unsafe fn get_unchecked_mut(&mut self, index: [usize; 2]) -> &T {
+    pub unsafe fn get_unchecked_mut(&mut self, index: [usize; 2]) -> &mut T {
         self.data.get_unchecked_mut(index[0] * self.cols + index[1])
     }
 


### PR DESCRIPTION
This bidiagonal decomposition will allow us to implement a number of efficient SVD algorithms.

This PR also modifies the upper Hessenberg decomposition to consume the matrix. This is because the algorithm clones the input matrix as its first step anyway.

Finally this fixes a bug where `get_unchecked_mut` returned an `&T` instead of `&mut T`.