### PR TITLE
implement get_row_* for Matrix, MatrixSlice and MatrixSliceMut

### DIFF
--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -285,12 +285,11 @@ impl<T> Matrix<T> {
     /// assert!(a.get_row(5).is_none());
     /// ```
     pub fn get_row(&self, index: usize) -> Option<&[T]> {
-
-        if index >= self.rows {
-            return None;
+        if index < self.rows {
+            unsafe { Some(self.get_row_unchecked(index)) }
+        } else {
+            None
         }
-
-        unsafe { Some(self.get_row_unchecked(index)) }
     }
 
     /// Returns the row of a `Matrix` at the given index without doing unbounds checking
@@ -327,12 +326,11 @@ impl<T> Matrix<T> {
     /// assert!(a.get_row_mut(5).is_none());
     /// ```
     pub fn get_row_mut(&mut self, index: usize) -> Option<&mut [T]> {
-
-        if index >= self.rows {
-            return None;
+        if index < self.rows {
+            unsafe { Some(self.get_row_unchecked_mut(index)) }
+        } else {
+            None
         }
-
-        unsafe { Some(self.get_row_unchecked_mut(index)) }
     }
 
     /// Returns a mutable reference to the row of a `Matrix` at the given index

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -269,6 +269,89 @@ impl<T> Matrix<T> {
         let cols = self.cols;
         MatrixSliceMut::from_matrix(self, [0, 0], rows, cols)
     }
+
+    /// Returns the row of a `Matrix` at the given index.
+    /// `None` if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::Matrix;
+    ///
+    /// let a = Matrix::new(3, 4, vec![2.0; 12]);
+    /// let row = a.get_row(1);
+    /// let expected = vec![2.0; 4];
+    /// assert_eq!(row, Some(&*expected));
+    /// assert!(a.get_row(5).is_none());
+    /// ```
+    pub fn get_row(&self, index: usize) -> Option<&[T]> {
+
+        if index >= self.rows {
+            return None;
+        }
+
+        unsafe { Some(self.get_row_unchecked(index)) }
+    }
+
+    /// Returns the row of a `Matrix` at the given index without doing unbounds checking
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::Matrix;
+    ///
+    /// let a = Matrix::new(3, 4, vec![2.0; 12]);
+    /// let row = unsafe { a.get_row_unchecked(1) };
+    /// let expected = vec![2.0; 4];
+    /// assert_eq!(row, &*expected);
+    /// ```
+    pub unsafe fn get_row_unchecked(&self, index: usize) -> &[T] {
+        let ptr = self.data.as_ptr().offset((self.cols * index) as isize);
+        ::std::slice::from_raw_parts(ptr, self.cols)
+    }
+
+    /// Returns a mutable reference to the row of a `Matrix` at the given index.
+    /// `None` if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::Matrix;
+    ///
+    /// let mut a = Matrix::new(3, 4, vec![2.0; 12]);
+    /// {
+    ///     let row = a.get_row_mut(1);
+    ///     let mut expected = vec![2.0; 4];
+    ///     assert_eq!(row, Some(&mut *expected));
+    /// }
+    /// assert!(a.get_row_mut(5).is_none());
+    /// ```
+    pub fn get_row_mut(&mut self, index: usize) -> Option<&mut [T]> {
+
+        if index >= self.rows {
+            return None;
+        }
+
+        unsafe { Some(self.get_row_mut_unchecked(index)) }
+    }
+
+    /// Returns a mutable reference to the row of a `Matrix` at the given index
+    /// without doing unbounds checking
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::Matrix;
+    ///
+    /// let mut a = Matrix::new(3, 4, vec![2.0; 12]);
+    /// let row = unsafe { a.get_row_mut_unchecked(1) };
+    /// let mut expected = vec![2.0; 4];
+    /// assert_eq!(row, &mut *expected);
+    /// ```
+    pub unsafe fn get_row_mut_unchecked(&mut self, index: usize) -> &mut [T] {
+        let ptr = self.data.as_mut_ptr().offset((self.cols * index) as isize);
+        ::std::slice::from_raw_parts_mut(ptr, self.cols)
+    }
 }
 
 impl<T: Clone> Clone for Matrix<T> {

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -332,7 +332,7 @@ impl<T> Matrix<T> {
             return None;
         }
 
-        unsafe { Some(self.get_row_mut_unchecked(index)) }
+        unsafe { Some(self.get_row_unchecked_mut(index)) }
     }
 
     /// Returns a mutable reference to the row of a `Matrix` at the given index
@@ -344,11 +344,11 @@ impl<T> Matrix<T> {
     /// use rulinalg::matrix::Matrix;
     ///
     /// let mut a = Matrix::new(3, 4, vec![2.0; 12]);
-    /// let row = unsafe { a.get_row_mut_unchecked(1) };
+    /// let row = unsafe { a.get_row_unchecked_mut(1) };
     /// let mut expected = vec![2.0; 4];
     /// assert_eq!(row, &mut *expected);
     /// ```
-    pub unsafe fn get_row_mut_unchecked(&mut self, index: usize) -> &mut [T] {
+    pub unsafe fn get_row_unchecked_mut(&mut self, index: usize) -> &mut [T] {
         let ptr = self.data.as_mut_ptr().offset((self.cols * index) as isize);
         ::std::slice::from_raw_parts_mut(ptr, self.cols)
     }

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -412,7 +412,7 @@ impl<'a, T> MatrixSliceMut<'a, T> {
             return None;
         }
 
-        unsafe { Some(self.get_row_mut_unchecked(index)) }
+        unsafe { Some(self.get_row_unchecked_mut(index)) }
     }
 
     /// Returns a mutable reference to the row of a `MatrixSliceMut` at the given index
@@ -426,11 +426,11 @@ impl<'a, T> MatrixSliceMut<'a, T> {
     ///
     /// let mut a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
     /// let mut slice = MatrixSliceMut::from_matrix(&mut a, [1,1], 2, 2);
-    /// let row = unsafe { slice.get_row_mut_unchecked(1) };
+    /// let row = unsafe { slice.get_row_unchecked_mut(1) };
     /// let mut expected = vec![7usize, 8];
     /// assert_eq!(row, &mut *expected);
     /// ```
-    pub unsafe fn get_row_mut_unchecked(&mut self, index: usize) -> &mut [T] {
+    pub unsafe fn get_row_unchecked_mut(&mut self, index: usize) -> &mut [T] {
         let ptr = self.ptr.offset((self.row_stride * index) as isize);
         ::std::slice::from_raw_parts_mut(ptr, self.cols)
     }

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -39,7 +39,27 @@ pub trait BaseSlice<T> {
     fn as_ptr(&self) -> *const T;
 
     /// Get a reference to a point in the slice without bounds checking.
-    unsafe fn get_unchecked(&self, index: [usize; 2]) -> &T;
+    unsafe fn get_unchecked(&self, index: [usize; 2]) -> &T {
+        &*(self.as_ptr().offset((index[0] * self.row_stride() + index[1]) as isize))
+    }
+
+    /// Returns the row of a `Matrix` at the given index.
+    /// `None` if the index is out of bounds.
+    fn get_row(&self, index: usize) -> Option<&[T]> {
+
+        if index >= self.rows() {
+            return None;
+        }
+
+        unsafe { Some(self.get_row_unchecked(index)) }
+    }
+    
+    /// Returns the row of a `BaseSlice` at the given index without doing unbounds checking
+    unsafe fn get_row_unchecked(&self, index: usize) -> &[T] {
+        let ptr = self.as_ptr().offset((self.row_stride() * index) as isize);
+        ::std::slice::from_raw_parts(ptr, self.cols())
+    }
+
 }
 
 impl<'a, T> BaseSlice<T> for MatrixSlice<'a, T> {
@@ -58,10 +78,6 @@ impl<'a, T> BaseSlice<T> for MatrixSlice<'a, T> {
     fn as_ptr(&self) -> *const T {
         self.ptr
     }
-
-    unsafe fn get_unchecked(&self, index: [usize; 2]) -> &T {
-        &*(self.ptr.offset((index[0] * self.row_stride + index[1]) as isize))
-    }
 }
 
 impl<'a, T> BaseSlice<T> for MatrixSliceMut<'a, T> {
@@ -79,10 +95,6 @@ impl<'a, T> BaseSlice<T> for MatrixSliceMut<'a, T> {
 
     fn as_ptr(&self) -> *const T {
         self.ptr as *const T
-    }
-
-    unsafe fn get_unchecked(&self, index: [usize; 2]) -> &T {
-        &*(self.ptr.offset((index[0] * self.row_stride + index[1]) as isize))
     }
 }
 
@@ -374,6 +386,53 @@ impl<'a, T> MatrixSliceMut<'a, T> {
             row_stride: self.row_stride,
             _marker: PhantomData::<&mut T>,
         }
+    }
+
+    /// Returns a mutable reference to the row of a `MatrixSliceMut` at the given index.
+    /// `None` if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::Matrix;
+    /// use rulinalg::matrix::MatrixSliceMut;
+    ///
+    /// let mut a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut slice = MatrixSliceMut::from_matrix(&mut a, [1,1], 2, 2);
+    /// {
+    ///     let row = slice.get_row_mut(1);
+    ///     let mut expected = vec![7usize, 8];
+    ///     assert_eq!(row, Some(&mut *expected));
+    /// }
+    /// assert!(slice.get_row_mut(5).is_none());
+    /// ```
+    pub fn get_row_mut(&mut self, index: usize) -> Option<&mut [T]> {
+
+        if index >= self.rows {
+            return None;
+        }
+
+        unsafe { Some(self.get_row_mut_unchecked(index)) }
+    }
+
+    /// Returns a mutable reference to the row of a `MatrixSliceMut` at the given index
+    /// without doing unbounds checking
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::Matrix;
+    /// use rulinalg::matrix::MatrixSliceMut;
+    ///
+    /// let mut a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut slice = MatrixSliceMut::from_matrix(&mut a, [1,1], 2, 2);
+    /// let row = unsafe { slice.get_row_mut_unchecked(1) };
+    /// let mut expected = vec![7usize, 8];
+    /// assert_eq!(row, &mut *expected);
+    /// ```
+    pub unsafe fn get_row_mut_unchecked(&mut self, index: usize) -> &mut [T] {
+        let ptr = self.ptr.offset((self.row_stride * index) as isize);
+        ::std::slice::from_raw_parts_mut(ptr, self.cols)
     }
 }
 

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -45,16 +45,42 @@ pub trait BaseSlice<T> {
 
     /// Returns the row of a `Matrix` at the given index.
     /// `None` if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::{Matrix, MatrixSlice};
+    /// use rulinalg::matrix::slice::BaseSlice;
+    ///
+    /// let mut a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut slice = MatrixSlice::from_matrix(&mut a, [1,1], 2, 2);
+    /// let row = slice.get_row(1);
+    /// let mut expected = vec![7usize, 8];
+    /// assert_eq!(row, Some(&*expected));
+    /// assert!(slice.get_row(5).is_none());
+    /// ```
     fn get_row(&self, index: usize) -> Option<&[T]> {
-
-        if index >= self.rows() {
-            return None;
+        if index < self.rows() {
+            unsafe { Some(self.get_row_unchecked(index)) }
+        } else {
+            None
         }
-
-        unsafe { Some(self.get_row_unchecked(index)) }
     }
     
     /// Returns the row of a `BaseSlice` at the given index without doing unbounds checking
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::{Matrix, MatrixSlice};
+    /// use rulinalg::matrix::slice::BaseSlice;
+    ///
+    /// let mut a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut slice = MatrixSlice::from_matrix(&mut a, [1,1], 2, 2);
+    /// let row = unsafe { slice.get_row_unchecked(1) };
+    /// let mut expected = vec![7usize, 8];
+    /// assert_eq!(row, &*expected);
+    /// ```
     unsafe fn get_row_unchecked(&self, index: usize) -> &[T] {
         let ptr = self.as_ptr().offset((self.row_stride() * index) as isize);
         ::std::slice::from_raw_parts(ptr, self.cols())
@@ -407,12 +433,11 @@ impl<'a, T> MatrixSliceMut<'a, T> {
     /// assert!(slice.get_row_mut(5).is_none());
     /// ```
     pub fn get_row_mut(&mut self, index: usize) -> Option<&mut [T]> {
-
-        if index >= self.rows {
-            return None;
+        if index < self.rows {
+            unsafe { Some(self.get_row_unchecked_mut(index)) }
+        } else {
+            None
         }
-
-        unsafe { Some(self.get_row_unchecked_mut(index)) }
     }
 
     /// Returns a mutable reference to the row of a `MatrixSliceMut` at the given index


### PR DESCRIPTION
- get_row
- get_row_mut
- get_row_unchecked
- get_row_mut_unchecked

Note:
For MatrixSlices, get_row and get_row_unchecked are implemented
directly on BaseSlice trait, as it already provides all necessary methods.

Similarly, moved get_unchecked slice implementations directly into the
trait, I don't really know but this may be a breaking change (I can revert this part if necessary).