### PR TITLE
Handle error cases for `mean` and `variance`.

### DIFF
--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -334,11 +334,11 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// // Only one column
     /// let b = Matrix::<f32>::new(2,1,vec![1.0,2.0]);
     ///
-    /// let e = b.variance(Axes::Row);
+    /// let e = b.variance(Axes::Row).unwrap();
     /// assert_eq!(*e.data(), vec![0.5]);
     ///
-    /// let f = b.variance(Axes::Col).unwrap();
-    /// assert!(*f.is_err());
+    /// let f = b.variance(Axes::Col);
+    /// assert!(f.is_err());
     ///
     /// ```
     /// // Empty matrix
@@ -347,7 +347,7 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// let b = a.variance(Axes::Row);
     /// assert!(b.is_err());
     ///
-    /// let c = b.variance(Axes::Col);
+    /// let c = a.variance(Axes::Col);
     /// assert!(c.is_err());
     /// ```
     ///

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -371,14 +371,10 @@ impl<T: Float + FromPrimitive> Matrix<T> {
             }
         }
 
-        if n == 0 {
+        if n < 2 {
             return Err(Error::new(ErrorKind::InvalidArg,
-                                  "There is no data in the working axis."));
-        }
-
-        if n == 1 {
-            return Err(Error::new(ErrorKind::InvalidArg,
-                                  "There is only one row or column in the working axis."));
+                                  "There must be at least two rows or columns in the working \
+                                   axis."));
         }
 
         let mut variance = Vector::zeros(m);

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -322,6 +322,7 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// ```
     /// use rulinalg::matrix::{Matrix, Axes};
     ///
+    /// // Only one row
     /// let a = Matrix::<f32>::new(1,2,vec![1.0,2.0]);
     ///
     /// let c = a.variance(Axes::Row);
@@ -330,13 +331,24 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// let d = a.variance(Axes::Col).unwrap();
     /// assert_eq!(*d.data(), vec![0.5]);
     ///
-    /// let b = Matrix::<f32>::new(0,0,vec![]);
+    /// // Only one column
+    /// let b = Matrix::<f32>::new(2,1,vec![1.0,2.0]);
     ///
     /// let e = b.variance(Axes::Row);
-    /// assert!(e.is_err());
+    /// assert_eq!(*e.data(), vec![0.5]);
     ///
-    /// let f = b.variance(Axes::Col);
-    /// assert!(f.is_err());
+    /// let f = b.variance(Axes::Col).unwrap();
+    /// assert!(*f.is_err());
+    ///
+    /// ```
+    /// // Empty matrix
+    /// let a = Matrix::<f32>::new(0,0,vec![]);
+    ///
+    /// let b = a.variance(Axes::Row);
+    /// assert!(b.is_err());
+    ///
+    /// let c = b.variance(Axes::Col);
+    /// assert!(c.is_err());
     /// ```
     ///
     /// # Failures

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -280,7 +280,7 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// assert_eq!(*d.data(), vec![]);
     /// ```
     pub fn mean(&self, axis: Axes) -> Vector<T> {
-        if self.rows == 0 {
+        if self.data.len() == 0 {
             // If the matrix is empty, there are no means to calculate.
             return Vector::new(vec![]);
         }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -297,8 +297,8 @@ impl<T: Float + FromPrimitive> Matrix<T> {
 
     /// The variance of the matrix along the specified axis.
     ///
-    /// Axis Row - Sample variance of rows.
-    /// Axis Col - Sample variance of columns.
+    /// - Axis Row - Sample variance of rows.
+    /// - Axis Col - Sample variance of columns.
     ///
     /// # Examples
     ///
@@ -323,27 +323,11 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// let c = a.variance(Axes::Row);
     /// assert!(c.is_err());
     ///
-    /// let d = a.variance(Axes::Col).unwrap();
-    /// assert_eq!(*d.data(), vec![0.5]);
-    ///
-    /// // Only one column
-    /// let b = Matrix::<f32>::new(2,1,vec![1.0,2.0]);
-    ///
-    /// let e = b.variance(Axes::Row).unwrap();
-    /// assert_eq!(*e.data(), vec![0.5]);
-    ///
-    /// let f = b.variance(Axes::Col);
-    /// assert!(f.is_err());
-    ///
-    /// ```
     /// // Empty matrix
-    /// let a = Matrix::<f32>::new(0,0,vec![]);
+    /// let b = Matrix::<f32>::new(0,0,vec![]);
     ///
-    /// let b = a.variance(Axes::Row);
-    /// assert!(b.is_err());
-    ///
-    /// let c = a.variance(Axes::Col);
-    /// assert!(c.is_err());
+    /// let d = b.variance(Axes::Row);
+    /// assert!(d.is_err());
     /// ```
     ///
     /// # Failures
@@ -1010,5 +994,37 @@ mod tests {
 
         let d = a.mean(Axes::Col);
         assert_eq!(*d.data(), vec![]);
+    }
+
+    #[test]
+    fn test_invalid_variance() {
+        use super::Axes;
+
+        // Only one row
+        let a = Matrix::<f32>::new(1, 2, vec![1.0, 2.0]);
+
+        let a_row = a.variance(Axes::Row);
+        assert!(a_row.is_err());
+
+        let a_col = a.variance(Axes::Col).unwrap();
+        assert_eq!(*a_col.data(), vec![0.5]);
+
+        // Only one column
+        let b = Matrix::<f32>::new(2, 1, vec![1.0, 2.0]);
+
+        let b_row = b.variance(Axes::Row).unwrap();
+        assert_eq!(*b_row.data(), vec![0.5]);
+
+        let b_col = b.variance(Axes::Col);
+        assert!(b_col.is_err());
+
+        // Empty matrix
+        let d = Matrix::<f32>::new(0, 0, vec![]);
+
+        let d_row = d.variance(Axes::Row);
+        assert!(d_row.is_err());
+
+        let d_col = d.variance(Axes::Col);
+        assert!(d_col.is_err());
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -267,7 +267,24 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// let d = a.mean(Axes::Col);
     /// assert_eq!(*d.data(), vec![1.5, 3.5]);
     /// ```
+    ///
+    /// ```
+    /// use rulinalg::matrix::{Matrix, Axes};
+    ///
+    /// let a = Matrix::<f64>::new(0,0, vec![]);
+    ///
+    /// let c = a.mean(Axes::Row);
+    /// assert_eq!(*c.data(), vec![]);
+    ///
+    /// let d = a.mean(Axes::Col);
+    /// assert_eq!(*d.data(), vec![]);
+    /// ```
     pub fn mean(&self, axis: Axes) -> Vector<T> {
+        if self.rows == 0 {
+            // If the matrix is empty, there are no means to calculate.
+            return Vector::new(vec![]);
+        }
+
         let m: Vector<T>;
         let n: T;
         match axis {

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -312,13 +312,29 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     ///
     /// let a = Matrix::<f32>::new(2,2,vec![1.0,2.0,3.0,4.0]);
     ///
-    /// let c = a.variance(Axes::Row);
+    /// let c = a.variance(Axes::Row).unwrap();
     /// assert_eq!(*c.data(), vec![2.0, 2.0]);
     ///
-    /// let d = a.variance(Axes::Col);
+    /// let d = a.variance(Axes::Col).unwrap();
     /// assert_eq!(*d.data(), vec![0.5, 0.5]);
     /// ```
-    pub fn variance(&self, axis: Axes) -> Vector<T> {
+    ///
+    /// ```
+    /// use rulinalg::matrix::{Matrix, Axes};
+    ///
+    /// let a = Matrix::<f32>::new(1,2,vec![1.0,2.0]);
+    ///
+    /// let c = a.variance(Axes::Row);
+    /// assert!(c.is_err());
+    ///
+    /// let d = a.variance(Axes::Col).unwrap();
+    /// assert_eq!(*d.data(), vec![0.5]);
+    /// ```
+    ///
+    /// # Failures
+    ///
+    /// - There is only one row/column in the working axis.
+    pub fn variance(&self, axis: Axes) -> Result<Vector<T>, Error> {
         let mean = self.mean(axis);
 
         let n: usize;
@@ -333,6 +349,11 @@ impl<T: Float + FromPrimitive> Matrix<T> {
                 n = self.cols;
                 m = self.rows;
             }
+        }
+
+        if n == 1 {
+            return Err(Error::new(ErrorKind::InvalidArg,
+                                  "There is only one row or column in the working axis."));
         }
 
         let mut variance = Vector::zeros(m);
@@ -358,12 +379,11 @@ impl<T: Float + FromPrimitive> Matrix<T> {
         }
 
         let var_size: T = FromPrimitive::from_usize(n - 1).unwrap();
-        variance / var_size
+        Ok(variance / var_size)
     }
 }
 
 impl<T: Any + Float> Matrix<T> {
-
     /// Solves the equation `Ax = y`.
     ///
     /// Requires a Vector `y` as input.

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -251,8 +251,10 @@ impl<T: Clone + Zero + One> Matrix<T> {
 impl<T: Float + FromPrimitive> Matrix<T> {
     /// The mean of the matrix along the specified axis.
     ///
-    /// Axis Row - Arithmetic mean of rows.
-    /// Axis Col - Arithmetic mean of columns.
+    /// - Axis Row - Arithmetic mean of rows.
+    /// - Axis Col - Arithmetic mean of columns.
+    ///
+    /// Calling `mean()` on an empty matrix will return an empty matrix.
     ///
     /// # Examples
     ///
@@ -266,18 +268,11 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     ///
     /// let d = a.mean(Axes::Col);
     /// assert_eq!(*d.data(), vec![1.5, 3.5]);
-    /// ```
     ///
-    /// ```
-    /// use rulinalg::matrix::{Matrix, Axes};
+    /// let b = Matrix::<f64>::new(0,0, vec![]);
     ///
-    /// let a = Matrix::<f64>::new(0,0, vec![]);
-    ///
-    /// let c = a.mean(Axes::Row);
-    /// assert_eq!(*c.data(), vec![]);
-    ///
-    /// let d = a.mean(Axes::Col);
-    /// assert_eq!(*d.data(), vec![]);
+    /// let e = b.mean(Axes::Row);
+    /// assert_eq!(*e.data(), vec![]);
     /// ```
     pub fn mean(&self, axis: Axes) -> Vector<T> {
         if self.data.len() == 0 {
@@ -1002,5 +997,18 @@ mod tests {
         assert_eq!(a[[0, 1]], 0.0);
         assert_eq!(a[[2, 1]], 0.0);
         assert_eq!(a[[3, 0]], 0.0);
+    }
+
+    #[test]
+    fn test_empty_mean() {
+        use super::Axes;
+
+        let a = Matrix::<f64>::new(0, 0, vec![]);
+
+        let c = a.mean(Axes::Row);
+        assert_eq!(*c.data(), vec![]);
+
+        let d = a.mean(Axes::Col);
+        assert_eq!(*d.data(), vec![]);
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -268,11 +268,6 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     ///
     /// let d = a.mean(Axes::Col);
     /// assert_eq!(*d.data(), vec![1.5, 3.5]);
-    ///
-    /// let b = Matrix::<f64>::new(0,0, vec![]);
-    ///
-    /// let e = b.mean(Axes::Row);
-    /// assert_eq!(*e.data(), vec![]);
     /// ```
     pub fn mean(&self, axis: Axes) -> Vector<T> {
         if self.data.len() == 0 {
@@ -312,22 +307,6 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     ///
     /// let d = a.variance(Axes::Col).unwrap();
     /// assert_eq!(*d.data(), vec![0.5, 0.5]);
-    /// ```
-    ///
-    /// ```
-    /// use rulinalg::matrix::{Matrix, Axes};
-    ///
-    /// // Only one row
-    /// let a = Matrix::<f32>::new(1,2,vec![1.0,2.0]);
-    ///
-    /// let c = a.variance(Axes::Row);
-    /// assert!(c.is_err());
-    ///
-    /// // Empty matrix
-    /// let b = Matrix::<f32>::new(0,0,vec![]);
-    ///
-    /// let d = b.variance(Axes::Row);
-    /// assert!(d.is_err());
     /// ```
     ///
     /// # Failures

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -329,11 +329,19 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     ///
     /// let d = a.variance(Axes::Col).unwrap();
     /// assert_eq!(*d.data(), vec![0.5]);
+    ///
+    /// let b = Matrix::<f32>::new(0,0,vec![]);
+    ///
+    /// let e = b.variance(Axes::Row);
+    /// assert!(e.is_err());
+    ///
+    /// let f = b.variance(Axes::Col);
+    /// assert!(f.is_err());
     /// ```
     ///
     /// # Failures
     ///
-    /// - There is only one row/column in the working axis.
+    /// - There are one or fewer row/columns in the working axis.
     pub fn variance(&self, axis: Axes) -> Result<Vector<T>, Error> {
         let mean = self.mean(axis);
 
@@ -349,6 +357,11 @@ impl<T: Float + FromPrimitive> Matrix<T> {
                 n = self.cols;
                 m = self.rows;
             }
+        }
+
+        if n == 0 {
+            return Err(Error::new(ErrorKind::InvalidArg,
+                                  "There is no data in the working axis."));
         }
 
         if n == 1 {


### PR DESCRIPTION
This resolves #20 with the following changes:

- Calling `mean` on an empty matrix returns an empty matrix vector.
- Calling `variance` on a matrix with one or fewer rows/columns in the working axis returns an `Error` with kind `InvalidArg`.