### PR TITLE
Implement simple macro for matrix creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,11 @@
 extern crate num as libnum;
 extern crate matrixmultiply;
 
+// macros should be at the top in order for macros to be accessible in subsequent modules
+#[macro_use]
+pub mod macros;
 pub mod matrix;
 pub mod convert;
-pub mod macros;
 pub mod error;
 pub mod utils;
 pub mod vector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,23 @@
 //! let c = a + b;
 //! ```
 //!
+//! Sometimes we want to construct small matrices by hand, usually for writing unit tests
+//! or examples. For this purpose, `rulinalg` provides the `matrix!` macro:
+//!
+//! ```
+//! // Remember to enable macro usage in rulinalg!
+//! #[macro_use]
+//! extern crate rulinalg;
+//!
+//! # fn main() {
+//! // Construct a 3x3 matrix of f64
+//! // Commas separate columns and semi-colons separate rows
+//! let mat = matrix!(1.0, 2.0, 3.0;
+//!                   4.0, 5.0, 6.0;
+//!                   7.0, 8.0, 9.0);
+//! # }
+//! ```
+//!
 //! Of course the library can support more complex operations but you should check the individual
 //! modules for more information.
 //!

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -743,6 +743,21 @@ fn parity<T, M>(m: &M) -> T
     sgn
 }
 
+macro_rules! matrix {
+    ($( $( $x: expr ),*);*) => {
+        {
+            let data_as_nested_array = [ $( [ $($x),* ] ),* ];
+            let rows = data_as_nested_array.len();
+            let cols = data_as_nested_array[0].len();
+            let data_as_flat_array: Vec<_> = data_as_nested_array.into_iter()
+                .flat_map(|row| row.into_iter())
+                .map(|x| x.to_owned())
+                .collect();
+            Matrix::new(rows, cols, data_as_flat_array)
+        }
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -961,6 +976,46 @@ mod tests {
         assert_eq!(a[[2, 1]], 0.0);
         assert_eq!(a[[3, 0]], 0.0);
     }
+
+    #[test]
+    fn create_mat_macro() {
+        {
+            // An arbitrary rectangular matrix
+            let mat = matrix!(1, 2, 3;
+                              4, 5, 6);
+            assert_eq!(2, mat.rows());
+            assert_eq!(3, mat.cols());
+            assert_eq!(&vec![1, 2, 3, 4, 5, 6], mat.data());
+        }
+
+        {
+            // A single row
+            let mat = matrix!(1, 2, 3);
+            assert_eq!(1, mat.rows());
+            assert_eq!(3, mat.cols());
+            assert_eq!(&vec![1, 2, 3], mat.data());
+        }
+
+        {
+            // A single element
+            let mat = matrix!(1);
+            assert_eq!(1, mat.rows());
+            assert_eq!(1, mat.cols());
+            assert_eq!(&vec![1], mat.data());
+        }
+
+        {
+            // A floating point matrix
+            let mat = matrix!(1.0, 2.0, 3.0;
+                              4.0, 5.0, 6.0;
+                              7.0, 8.0, 9.0);
+            let ref expected_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+            assert_eq!(3, mat.rows());
+            assert_eq!(3, mat.cols());
+            assert_eq!(expected_data, mat.data());
+        }
+    }
+
 
     #[test]
     fn test_empty_mean() {

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -743,22 +743,6 @@ fn parity<T, M>(m: &M) -> T
     sgn
 }
 
-macro_rules! matrix {
-    ($( $( $x: expr ),*);*) => {
-        {
-            let data_as_nested_array = [ $( [ $($x),* ] ),* ];
-            let rows = data_as_nested_array.len();
-            let cols = data_as_nested_array[0].len();
-            let data_as_flat_array: Vec<_> = data_as_nested_array.into_iter()
-                .flat_map(|row| row.into_iter())
-                .map(|x| x.to_owned())
-                .collect();
-            Matrix::new(rows, cols, data_as_flat_array)
-        }
-    }
-}
-
-
 #[cfg(test)]
 mod tests {
     use super::super::vector::Vector;
@@ -976,46 +960,6 @@ mod tests {
         assert_eq!(a[[2, 1]], 0.0);
         assert_eq!(a[[3, 0]], 0.0);
     }
-
-    #[test]
-    fn create_mat_macro() {
-        {
-            // An arbitrary rectangular matrix
-            let mat = matrix!(1, 2, 3;
-                              4, 5, 6);
-            assert_eq!(2, mat.rows());
-            assert_eq!(3, mat.cols());
-            assert_eq!(&vec![1, 2, 3, 4, 5, 6], mat.data());
-        }
-
-        {
-            // A single row
-            let mat = matrix!(1, 2, 3);
-            assert_eq!(1, mat.rows());
-            assert_eq!(3, mat.cols());
-            assert_eq!(&vec![1, 2, 3], mat.data());
-        }
-
-        {
-            // A single element
-            let mat = matrix!(1);
-            assert_eq!(1, mat.rows());
-            assert_eq!(1, mat.cols());
-            assert_eq!(&vec![1], mat.data());
-        }
-
-        {
-            // A floating point matrix
-            let mat = matrix!(1.0, 2.0, 3.0;
-                              4.0, 5.0, 6.0;
-                              7.0, 8.0, 9.0);
-            let ref expected_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-            assert_eq!(3, mat.rows());
-            assert_eq!(3, mat.cols());
-            assert_eq!(expected_data, mat.data());
-        }
-    }
-
 
     #[test]
     fn test_empty_mean() {


### PR DESCRIPTION
There is no issue for this, but I've been missing a simple macro for creating small matrices. So I wrote a very simple one. It works like this:
```
let mat = matrix!(1.0, 2.0, 3.0;
                  4.0, 5.0, 6.0;
                  7.0, 8.0, 9.0);
```
As I'm sure you can infer from the example, you delimit columns by commas and rows by semi-colons, which is also the way MATLAB does it, except I chose to make the commas compulsory. Since I'm simply converting the expression to a Rust nested array, you get compiler errors if your matrix dimensions don't match, which is an advantage compared to constructor methods (which would also need you to specify rows and cols).

Such a macro is useful not just for ourselves when testing `rulinalg`, but for users of `rulinalg` who need to create small matrices when writing tests of their own applications.

What do you think?