### PR TITLE
Added impl for From/Into<Vec<T>> to Vector<T>.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -8,6 +8,17 @@ use std::convert::From;
 use super::matrix::{Matrix, MatrixSlice, MatrixSliceMut, BaseMatrix};
 use super::vector::Vector;
 
+impl<T> From<Vec<T>> for Vector<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Vector::new(vec)
+    }
+}
+
+impl<'a, T> From<&'a [T]> for Vector<T> where T: Clone {
+    fn from(slice: &'a [T]) -> Self {
+        Vector::new(slice.to_owned())
+    }
+}
 
 impl<T> From<Vector<T>> for Matrix<T> {
     fn from(vector: Vector<T>) -> Self {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -75,6 +75,12 @@ impl<T> Vector<T> {
 
 }
 
+impl<T> Into<Vec<T>> for Vector<T> {
+    fn into(self) -> Vec<T> {
+        self.data
+    }
+}
+
 impl<T> IntoIterator for Vector<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -83,7 +89,6 @@ impl<T> IntoIterator for Vector<T> {
         self.data.into_iter()
     }
 }
-
 
 impl<'a, T> IntoIterator for &'a Vector<T> {
     type Item = &'a T;
@@ -690,7 +695,7 @@ impl<T> Index<usize> for Vector<T> {
 impl<T> IndexMut<usize> for Vector<T> {
     fn index_mut(&mut self, idx: usize) -> &mut T {
         assert!(idx < self.size);
-        unsafe { self.data.get_unchecked_mut(idx) } 
+        unsafe { self.data.get_unchecked_mut(idx) }
     }
 }
 


### PR DESCRIPTION
**Motivation**:
Basically the common conveniences associated with `From` and `Into` traits, such as being able to pass `vec![…]` to `fn foo(vec: Vector<T>) { … }` instead of `Vector::new(vec![…])`.

Also it just kinda makes sense being a shallow wrapper around `Vec<T>`.