### PR TITLE
Return 0 from det() instead of LUP error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,17 +9,15 @@ use std::marker::{Send, Sync};
 /// An error related to the linalg module.
 #[derive(Debug)]
 pub struct Error {
-    /// Type of error that led to this issue
-    pub kind: ErrorKind,
-    /// Boxed actual error for easy passing
-    pub error: Box<error::Error + Send + Sync>,
+    kind: ErrorKind,
+    error: Box<error::Error + Send + Sync>,
 }
 
 /// Types of errors produced in the linalg module.
 ///
 /// List intended to grow and so you should
 /// be wary of matching against explicitly.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ErrorKind {
     /// An argument did not uphold a necessary criteria for the function.
     InvalidArg,

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,10 @@ use std::marker::{Send, Sync};
 /// An error related to the linalg module.
 #[derive(Debug)]
 pub struct Error {
-    kind: ErrorKind,
-    error: Box<error::Error + Send + Sync>,
+    /// Type of error that led to this issue
+    pub kind: ErrorKind,
+    /// Boxed actual error for easy passing
+    pub error: Box<error::Error + Send + Sync>,
 }
 
 /// Types of errors produced in the linalg module.
@@ -25,6 +27,8 @@ pub enum ErrorKind {
     DecompFailure,
     /// A failure due to some algebraic constraints not being met.
     AlgebraFailure,
+    /// Tried to divide by zero
+    DivByZero
 }
 
 impl Error {

--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -1496,4 +1496,18 @@ mod tests {
 
         let _ = a.lup_decomp();
     }
+
+    #[test]
+    fn test_lup_decomp() {
+        use error::ErrorKind;
+        let a = Matrix::<f64>::new(4, 4, vec![
+                                   1., 2., 3., 4., 
+                                   0., 0., 0., 0., 
+                                   0., 0., 0., 0., 
+                                   0., 0., 0., 0.]);
+        match a.lup_decomp() {
+            Err(e) => assert!(*e.kind() == ErrorKind::DivByZero),
+            Ok(_) => panic!()
+        }
+    }
 }

--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -1157,8 +1157,8 @@ impl<T> Matrix<T> where T: Any + Copy + One + Zero + Neg<Output=T> +
                 let denom = u[[i,i]];
 
                 if denom == T::zero() {
-                    return Err(Error::new(ErrorKind::DecompFailure,
-                        "Matrix could not be LUP decomposed."));
+                    return Err(Error::new(ErrorKind::DivByZero,
+                        "A value in the diagonal of U == 0.0."));
                 }
                 l.data[j*n + i] = (a_2[[j,i]] - s2) / denom;
             }

--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -1500,11 +1500,13 @@ mod tests {
     #[test]
     fn test_lup_decomp() {
         use error::ErrorKind;
-        let a = Matrix::<f64>::new(4, 4, vec![
-                                   1., 2., 3., 4., 
-                                   0., 0., 0., 0., 
-                                   0., 0., 0., 0., 
-                                   0., 0., 0., 0.]);
+        let a: Matrix<f64> = matrix!(
+            1., 2., 3., 4.;
+            0., 0., 0., 0.;
+            0., 0., 0., 0.;
+            0., 0., 0., 0.
+        );
+
         match a.lup_decomp() {
             Err(e) => assert!(*e.kind() == ErrorKind::DivByZero),
             Ok(_) => panic!()

--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -1158,7 +1158,8 @@ impl<T> Matrix<T> where T: Any + Copy + One + Zero + Neg<Output=T> +
 
                 if denom == T::zero() {
                     return Err(Error::new(ErrorKind::DivByZero,
-                        "A value in the diagonal of U == 0.0."));
+                        "Singular matrix found in LUP decomposition. \
+                        A value in the diagonal of U == 0.0."));
                 }
                 l.data[j*n + i] = (a_2[[j,i]] - s2) / denom;
             }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -543,7 +543,7 @@ impl<T: Any + Float> Matrix<T> {
         } else {
             let (l, u, p) = match self.lup_decomp() {
                 Ok(x) => x,
-                Err(Error { kind: ErrorKind::DivByZero, .. }) => return T::zero(),
+                Err(ref e) if *e.kind() == ErrorKind::DivByZero => return T::zero(),
                 _ => { panic!("Could not compute LUP decomposition."); }
             };
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -541,7 +541,11 @@ impl<T: Any + Float> Matrix<T> {
             (self[[0, 1]] * self[[1, 0]] * self[[2, 2]]) -
             (self[[0, 2]] * self[[1, 1]] * self[[2, 0]])
         } else {
-            let (l, u, p) = self.lup_decomp().expect("Could not compute LUP decomposition.");
+            let (l, u, p) = match self.lup_decomp() {
+                Ok(x) => x,
+                Err(Error { kind: ErrorKind::DivByZero, .. }) => return T::zero(),
+                _ => { panic!("Could not compute LUP decomposition."); }
+            };
 
             let mut d = T::one();
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -953,11 +953,12 @@ mod tests {
         let error = abs(f - 99.);
         assert!(error < 1e-10);
 
-        let g = Matrix::<f64>::new(4, 4, vec![
-                                   1., 2., 3., 4., 
-                                   0., 0., 0., 0., 
-                                   0., 0., 0., 0., 
-                                   0., 0., 0., 0.]);
+        let g: Matrix<f64> = matrix!(
+            1., 2., 3., 4.;
+            0., 0., 0., 0.;
+            0., 0., 0., 0.;
+            0., 0., 0., 0.
+        );
         let h = g.det();
         assert_eq!(h, 0.);
     }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -952,6 +952,14 @@ mod tests {
         println!("det is {0}", f);
         let error = abs(f - 99.);
         assert!(error < 1e-10);
+
+        let g = Matrix::<f64>::new(4, 4, vec![
+                                   1., 2., 3., 4., 
+                                   0., 0., 0., 0., 
+                                   0., 0., 0., 0., 
+                                   0., 0., 0., 0.]);
+        let h = g.det();
+        assert_eq!(h, 0.);
     }
 
     #[test]


### PR DESCRIPTION
LUP factorization will return an error whenever one of the diagonals of the U
matrix is == 0. This generally makes sense, because such a matrix is
singular and there will probably be an error down the line anyway. However, the
determinant of this matrix is known, and is 0, because the determinant is
calculated as the product of the diagonal of the triangular matrix.

I believe that it is more general to return the correct result for the
determinant (0) rather than raising an error. Let the end-user decide what to
do about this determinant of 0.