### PR TITLE
Moved bounds out of generic arguments

### DIFF
--- a/src/matrix/decomposition.rs
+++ b/src/matrix/decomposition.rs
@@ -25,7 +25,9 @@ use libnum::{One, Zero, Float, Signed};
 use libnum::{cast, abs};
 use epsilon::MachineEpsilon;
 
-impl<T: Any + Float> Matrix<T> {
+impl<T> Matrix<T>
+    where T: Any + Float
+{
     /// Cholesky decomposition
     ///
     /// Returns the cholesky decomposition of a positive definite matrix.
@@ -312,8 +314,12 @@ impl<T: Any + Float> Matrix<T> {
 /// The SVD is represented by matrices `(b, u, v)`, where `b` is the diagonal matrix
 /// containing the singular values, `u` is the matrix of left singular vectors
 /// and v is the matrix of right singular vectors.
-fn correct_svd_signs<T>(mut b: Matrix<T>, mut u: Matrix<T>, mut v: Matrix<T>)
-    -> (Matrix<T>, Matrix<T>, Matrix<T>) where T: Any + Float + Signed {
+fn correct_svd_signs<T>(mut b: Matrix<T>,
+                        mut u: Matrix<T>,
+                        mut v: Matrix<T>)
+                        -> (Matrix<T>, Matrix<T>, Matrix<T>)
+    where T: Any + Float + Signed
+{
 
     // When correcting the signs of the singular vectors, we can choose
     // to correct EITHER u or v. We make the choice depending on which matrix has the
@@ -340,8 +346,12 @@ fn correct_svd_signs<T>(mut b: Matrix<T>, mut u: Matrix<T>, mut v: Matrix<T>)
     (b, u, v)
 }
 
-fn sort_svd<T>(mut b: Matrix<T>, mut u: Matrix<T>, mut v: Matrix<T>)
-    -> (Matrix<T>, Matrix<T>, Matrix<T>) where T: Any + Float + Signed {
+fn sort_svd<T>(mut b: Matrix<T>,
+               mut u: Matrix<T>,
+               mut v: Matrix<T>)
+               -> (Matrix<T>, Matrix<T>, Matrix<T>)
+    where T: Any + Float + Signed
+{
 
     assert!(u.cols() == b.cols() && b.cols() == v.cols());
 

--- a/src/matrix/impl_ops.rs
+++ b/src/matrix/impl_ops.rs
@@ -85,7 +85,8 @@ macro_rules! impl_bin_op_scalar_slice (
 /// Scalar
 #[doc=$doc]
 /// with matrix slice.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<T> for $slice<'a, T> {
+impl<'a, T> $trt<T> for $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: T) -> Matrix<T> {
@@ -96,7 +97,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<T> for $slice<'a, T> {
 /// Scalar
 #[doc=$doc]
 /// with matrix slice.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b T> for $slice<'a, T> {
+impl<'a, 'b, T> $trt<&'b T> for $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: &T) -> Matrix<T> {
@@ -107,7 +109,8 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b T> for $slice<'a, T> {
 /// Scalar
 #[doc=$doc]
 /// with matrix slice.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<T> for &'b $slice<'a, T> {
+impl<'a, 'b, T> $trt<T> for &'b $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: T) -> Matrix<T> {
@@ -118,7 +121,8 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<T> for &'b $slice<'a, T> {
 /// Scalar
 #[doc=$doc]
 /// with matrix slice.
-impl<'a, 'b, 'c, T: Copy + $trt<T, Output=T>> $trt<&'c T> for &'b $slice<'a, T> {
+impl<'a, 'b, 'c, T> $trt<&'c T> for &'b $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: &T) -> Matrix<T> {
@@ -151,7 +155,8 @@ macro_rules! impl_bin_op_scalar_matrix (
 /// with matrix.
 ///
 /// Will reuse the memory allocated for the existing matrix.
-impl<T: Copy + $trt<T, Output=T>> $trt<T> for Matrix<T> {
+impl<T> $trt<T> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: T) -> Matrix<T> {
@@ -165,7 +170,8 @@ impl<T: Copy + $trt<T, Output=T>> $trt<T> for Matrix<T> {
 /// with matrix.
 ///
 /// Will reuse the memory allocated for the existing matrix.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<&'a T> for Matrix<T> {
+impl<'a, T> $trt<&'a T> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(mut self, f: &T) -> Matrix<T> {
@@ -181,7 +187,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<&'a T> for Matrix<T> {
 /// Scalar
 #[doc=$doc]
 /// with matrix.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<T> for &'a Matrix<T> {
+impl<'a, T> $trt<T> for &'a Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: T) -> Matrix<T> {
@@ -193,7 +200,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<T> for &'a Matrix<T> {
 /// Scalar
 #[doc=$doc]
 /// with matrix.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b T> for &'a Matrix<T> {
+impl<'a, 'b, T> $trt<&'b T> for &'a Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, f: &T) -> Matrix<T> {
@@ -351,7 +359,8 @@ macro_rules! impl_bin_op_mat_slice (
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for $slice<'a, T> {
+impl<'a, T> $trt<Matrix<T>> for $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, m: Matrix<T>) -> Matrix<T> {
@@ -362,7 +371,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for $slice<'a, T> {
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for &'b $slice<'a, T> {
+impl<'a, 'b, T> $trt<Matrix<T>> for &'b $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, m: Matrix<T>) -> Matrix<T> {
@@ -373,7 +383,8 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for &'b $slice<'a, T> 
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b Matrix<T>> for $slice<'a, T> {
+impl<'a, 'b, T> $trt<&'b Matrix<T>> for $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, m: &Matrix<T>) -> Matrix<T> {
@@ -384,7 +395,8 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b Matrix<T>> for $slice<'a, T> 
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, 'b, 'c, T: Copy + $trt<T, Output=T>> $trt<&'c Matrix<T>> for &'b $slice<'a, T> {
+impl<'a, 'b, 'c, T> $trt<&'c Matrix<T>> for &'b $slice<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, m: &Matrix<T>) -> Matrix<T> {
@@ -405,7 +417,8 @@ impl<'a, 'b, 'c, T: Copy + $trt<T, Output=T>> $trt<&'c Matrix<T>> for &'b $slice
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<$slice<'a, T>> for Matrix<T> {
+impl<'a, T> $trt<$slice<'a, T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, s: $slice<T>) -> Matrix<T> {
@@ -416,7 +429,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<$slice<'a, T>> for Matrix<T> {
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<$slice<'a, T>> for &'b Matrix<T> {
+impl<'a, 'b, T> $trt<$slice<'a, T>> for &'b Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, s: $slice<T>) -> Matrix<T> {
@@ -427,7 +441,8 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<$slice<'a, T>> for &'b Matrix<T> 
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b $slice<'a, T>> for Matrix<T> {
+impl<'a, 'b, T> $trt<&'b $slice<'a, T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, s: &$slice<T>) -> Matrix<T> {
@@ -438,7 +453,8 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b $slice<'a, T>> for Matrix<T> 
 /// Performs elementwise
 #[doc=$doc]
 /// between `Matrix` and `MatrixSlice`.
-impl<'a, 'b, 'c, T: Copy + $trt<T, Output=T>> $trt<&'c $slice<'a, T>> for &'b Matrix<T> {
+impl<'a, 'b, 'c, T> $trt<&'c $slice<'a, T>> for &'b Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, s: &$slice<T>) -> Matrix<T> {
@@ -472,7 +488,8 @@ macro_rules! impl_bin_op_mat (
 /// between two matrices.
 ///
 /// This will reuse allocated memory from `self`.
-impl<T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for Matrix<T> {
+impl<T> $trt<Matrix<T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, m: Matrix<T>) -> Matrix<T> {
@@ -485,7 +502,8 @@ impl<T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for Matrix<T> {
 /// between two matrices.
 ///
 /// This will reuse allocated memory from `m`.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for &'a Matrix<T> {
+impl<'a, T> $trt<Matrix<T>> for &'a Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, mut m: Matrix<T>) -> Matrix<T> {
@@ -502,7 +520,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<Matrix<T>> for &'a Matrix<T> {
 /// between two matrices.
 ///
 /// This will reuse allocated memory from `self`.
-impl<'a, T: Copy + $trt<T, Output=T>> $trt<&'a Matrix<T>> for Matrix<T> {
+impl<'a, T> $trt<&'a Matrix<T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(mut self, m: &Matrix<T>) -> Matrix<T> {
@@ -517,7 +536,8 @@ impl<'a, T: Copy + $trt<T, Output=T>> $trt<&'a Matrix<T>> for Matrix<T> {
 /// Performs elementwise
 #[doc=$doc]
 /// between two matrices.
-impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b Matrix<T>> for &'a Matrix<T> {
+impl<'a, 'b, T> $trt<&'b Matrix<T>> for &'a Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     type Output = Matrix<T>;
 
     fn $op(self, m: &Matrix<T>) -> Matrix<T> {
@@ -545,7 +565,8 @@ macro_rules! impl_op_assign_mat_scalar (
 /// Performs
 #[doc=$doc]
 /// assignment between a matrix and a scalar.
-impl<T : Copy + $trt<T, Output=T>> $assign_trt<T> for Matrix<T> {
+impl<T> $assign_trt<T> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: T) {
         for x in &mut self.data {
             *x = (*x).$op(_rhs)
@@ -556,7 +577,8 @@ impl<T : Copy + $trt<T, Output=T>> $assign_trt<T> for Matrix<T> {
 /// Performs
 #[doc=$doc]
 /// assignment between a matrix and a scalar.
-impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<&'a T> for Matrix<T> {
+impl<'a, T> $assign_trt<&'a T> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: &T) {
         for x in &mut self.data {
             *x = (*x).$op(*_rhs)
@@ -577,7 +599,8 @@ macro_rules! impl_op_assign_slice_scalar (
 /// Performs
 #[doc=$doc]
 /// assignment between a mutable matrix slice and a scalar.
-impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<T> for MatrixSliceMut<'a, T> {
+impl<'a, T> $assign_trt<T> for MatrixSliceMut<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: T) {
         for x in self.iter_mut() {
             *x = (*x).$op(_rhs)
@@ -588,7 +611,8 @@ impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<T> for MatrixSliceMut<'a, T> 
 /// Performs
 #[doc=$doc]
 /// assignment between a mutable matrix slice and a scalar.
-impl<'a, 'b, T : Copy + $trt<T, Output=T>> $assign_trt<&'b T> for MatrixSliceMut<'a, T> {
+impl<'a, 'b, T> $assign_trt<&'b T> for MatrixSliceMut<'a, T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: &T) {
         for x in self.iter_mut() {
             *x = (*x).$op(*_rhs)
@@ -609,7 +633,8 @@ macro_rules! impl_op_assign_mat (
 /// Performs elementwise
 #[doc=$doc]
 /// assignment between two matrices.
-impl<T : Copy + $trt<T, Output=T>> $assign_trt<Matrix<T>> for Matrix<T> {
+impl<T> $assign_trt<Matrix<T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T>  {
     fn $op_assign(&mut self, _rhs: Matrix<T>) {
         utils::in_place_vec_bin_op(&mut self.data, &_rhs.data, |x, &y| {*x = (*x).$op(y) });
     }
@@ -618,7 +643,8 @@ impl<T : Copy + $trt<T, Output=T>> $assign_trt<Matrix<T>> for Matrix<T> {
 /// Performs elementwise
 #[doc=$doc]
 /// assignment between two matrices.
-impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<&'a Matrix<T>> for Matrix<T> {
+impl<'a, T> $assign_trt<&'a Matrix<T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: &Matrix<T>) {
         utils::in_place_vec_bin_op(&mut self.data, &_rhs.data, |x, &y| {*x = (*x).$op(y) });
     }
@@ -636,7 +662,7 @@ macro_rules! impl_op_assign_slice_mat (
 #[doc=$doc]
 /// assignment between two matrices.
 impl<'a, T> $assign_trt<Matrix<T>> for MatrixSliceMut<'a, T>
-    where T : Copy + $trt<T, Output=T>
+    where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: Matrix<T>) {
         for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
@@ -649,7 +675,7 @@ impl<'a, T> $assign_trt<Matrix<T>> for MatrixSliceMut<'a, T>
 #[doc=$doc]
 /// assignment between two matrices.
 impl<'a, 'b, T> $assign_trt<&'b Matrix<T>> for MatrixSliceMut<'a, T>
-    where T : Copy + $trt<T, Output=T>
+    where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: &Matrix<T>) {
         for (slice_row, target_row) in self.iter_rows_mut()
@@ -675,7 +701,7 @@ macro_rules! impl_op_assign_slice (
 #[doc=$doc]
 /// assignment between two matrices.
 impl<'a, 'b, T> $assign_trt<$target_slice<'b, T>> for MatrixSliceMut<'a, T>
-    where T : Copy + $trt<T, Output=T>
+    where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: $target_slice<T>) {
         for (slice_row, target_row) in self.iter_rows_mut()
@@ -691,7 +717,7 @@ impl<'a, 'b, T> $assign_trt<$target_slice<'b, T>> for MatrixSliceMut<'a, T>
 #[doc=$doc]
 /// assignment between two matrices.
 impl<'a, 'b, 'c, T> $assign_trt<&'c $target_slice<'b, T>> for MatrixSliceMut<'a, T>
-    where T : Copy + $trt<T, Output=T>
+    where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: &$target_slice<T>) {
         for (slice_row, target_row) in self.iter_rows_mut()
@@ -716,7 +742,8 @@ macro_rules! impl_op_assign_mat_slice (
 /// Performs elementwise
 #[doc=$doc]
 /// assignment between two matrices.
-impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<$target_mat<'a, T>> for Matrix<T> {
+impl<'a, T> $assign_trt<$target_mat<'a, T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: $target_mat<T>) {
         for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
             utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
@@ -727,7 +754,8 @@ impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<$target_mat<'a, T>> for Matri
 /// Performs elementwise
 #[doc=$doc]
 /// assignment between two matrices.
-impl<'a, 'b, T : Copy + $trt<T, Output=T>> $assign_trt<&'b $target_mat<'a, T>> for Matrix<T> {
+impl<'a, 'b, T> $assign_trt<&'b $target_mat<'a, T>> for Matrix<T>
+    where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: &$target_mat<T>) {
         for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
             utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
@@ -746,7 +774,8 @@ macro_rules! impl_neg_slice (
     ($slice:ident) => (
 
 /// Gets negative of matrix slice.
-impl<'a, T: Neg<Output = T> + Copy> Neg for $slice<'a, T> {
+impl<'a, T> Neg for $slice<'a, T>
+    where T: Neg<Output = T> + Copy {
     type Output = Matrix<T>;
 
     fn neg(self) -> Matrix<T> {
@@ -755,7 +784,8 @@ impl<'a, T: Neg<Output = T> + Copy> Neg for $slice<'a, T> {
 }
 
 /// Gets negative of matrix slice.
-impl<'a, 'b, T: Neg<Output = T> + Copy> Neg for &'b $slice<'a, T> {
+impl<'a, 'b, T> Neg for &'b $slice<'a, T>
+    where T: Neg<Output = T> + Copy {
     type Output = Matrix<T>;
 
     fn neg(self) -> Matrix<T> {
@@ -776,7 +806,9 @@ impl_neg_slice!(MatrixSlice);
 impl_neg_slice!(MatrixSliceMut);
 
 /// Gets negative of matrix.
-impl<T: Neg<Output = T> + Copy> Neg for Matrix<T> {
+impl<T> Neg for Matrix<T>
+    where T: Neg<Output = T> + Copy
+{
     type Output = Matrix<T>;
 
     fn neg(mut self) -> Matrix<T> {
@@ -789,7 +821,9 @@ impl<T: Neg<Output = T> + Copy> Neg for Matrix<T> {
 }
 
 /// Gets negative of matrix.
-impl<'a, T: Neg<Output = T> + Copy> Neg for &'a Matrix<T> {
+impl<'a, T> Neg for &'a Matrix<T>
+    where T: Neg<Output = T> + Copy
+{
     type Output = Matrix<T>;
 
     fn neg(self) -> Matrix<T> {

--- a/src/matrix/mat_mul.rs
+++ b/src/matrix/mat_mul.rs
@@ -7,7 +7,10 @@ use libnum::Zero;
 use matrixmultiply;
 
 /// Return `true` if `A` and `B` are the same type
-fn same_type<A: Any, B: Any>() -> bool {
+fn same_type<A, B>() -> bool
+    where A: Any,
+          B: Any
+{
     TypeId::of::<A>() == TypeId::of::<B>()
 }
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -154,7 +154,8 @@ impl<T> Matrix<T> {
     /// ]);
     /// ```
     pub fn from_fn<F>(rows: usize, cols: usize, mut f: F) -> Matrix<T>
-        where F: FnMut(usize, usize) -> T {
+        where F: FnMut(usize, usize) -> T
+    {
         let mut data = Vec::with_capacity(rows * cols);
         for row in 0..rows {
             for col in 0..cols {
@@ -649,12 +650,14 @@ impl<T: fmt::Display> fmt::Display for Matrix<T> {
         }
         let width = max_datum_width;
 
-        fn write_row<T: fmt::Display>(f: &mut fmt::Formatter,
-                                      row: &[T],
-                                      left_delimiter: &str,
-                                      right_delimiter: &str,
-                                      width: usize)
-                                      -> Result<(), fmt::Error> {
+        fn write_row<T>(f: &mut fmt::Formatter,
+                        row: &[T],
+                        left_delimiter: &str,
+                        right_delimiter: &str,
+                        width: usize)
+                        -> Result<(), fmt::Error>
+            where T: fmt::Display
+        {
             try!(write!(f, "{}", left_delimiter));
             for (index, datum) in row.iter().enumerate() {
                 match f.precision() {
@@ -703,7 +706,7 @@ impl<T: fmt::Display> fmt::Display for Matrix<T> {
 /// Back substitution
 fn back_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
     where T: Any + Float,
-          M: BaseMatrix<T>,
+          M: BaseMatrix<T>
 {
     let mut x = vec![T::zero(); y.size()];
 
@@ -733,7 +736,7 @@ fn back_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
 /// forward substitution
 fn forward_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
     where T: Any + Float,
-          M: BaseMatrix<T>,
+          M: BaseMatrix<T>
 {
     let mut x = Vec::with_capacity(y.size());
 
@@ -761,7 +764,7 @@ fn forward_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
 /// Computes the parity of a permutation matrix.
 fn parity<T, M>(m: &M) -> T
     where T: Any + Float,
-          M: BaseMatrix<T>,
+          M: BaseMatrix<T>
 {
     let mut visited = vec![false; m.rows()];
     let mut sgn = T::one();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,8 +102,9 @@ pub fn unrolled_sum<T>(mut xs: &[T]) -> T
 /// // Will print a vector of `7`s.
 /// println!("{:?}", a);
 /// ```
-pub fn in_place_vec_bin_op<F, T: Copy>(mut u: &mut [T], v: &[T], mut f: F)
-    where F: FnMut(&mut T, &T)
+pub fn in_place_vec_bin_op<F, T>(mut u: &mut [T], v: &[T], mut f: F)
+    where F: FnMut(&mut T, &T),
+          T: Copy
 {
     debug_assert_eq!(u.len(), v.len());
     let len = cmp::min(u.len(), v.len());
@@ -131,8 +132,9 @@ pub fn in_place_vec_bin_op<F, T: Copy>(mut u: &mut [T], v: &[T], mut f: F)
 /// // Will print a vector of `7`s.
 /// println!("{:?}", a);
 /// ```
-pub fn vec_bin_op<F, T: Copy>(u: &[T], v: &[T], f: F) -> Vec<T>
-    where F: Fn(T, T) -> T
+pub fn vec_bin_op<F, T>(u: &[T], v: &[T], f: F) -> Vec<T>
+    where F: Fn(T, T) -> T,
+          T: Copy
 {
     debug_assert_eq!(u.len(), v.len());
     let len = cmp::min(u.len(), v.len());
@@ -240,7 +242,9 @@ pub fn ele_div<T: Copy + Div<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
 /// assert_eq!(c.0, 3);
 /// assert_eq!(c.1, 4.0);
 /// ```
-pub fn argmax<T: Copy + PartialOrd>(u: &[T]) -> (usize, T) {
+pub fn argmax<T>(u: &[T]) -> (usize, T)
+    where T: Copy + PartialOrd
+{
     assert!(u.len() != 0);
 
     let mut max_index = 0;
@@ -270,7 +274,9 @@ pub fn argmax<T: Copy + PartialOrd>(u: &[T]) -> (usize, T) {
 /// assert_eq!(c.0, 1);
 /// assert_eq!(c.1, 2.0);
 /// ```
-pub fn argmin<T: Copy + PartialOrd>(u: &[T]) -> (usize, T) {
+pub fn argmin<T>(u: &[T]) -> (usize, T)
+    where T: Copy + PartialOrd
+{
     assert!(u.len() != 0);
 
     let mut min_index = 0;
@@ -299,7 +305,9 @@ pub fn argmin<T: Copy + PartialOrd>(u: &[T]) -> (usize, T) {
 /// let c = utils::find(&a, 3.0);
 /// assert_eq!(c, 2);
 /// ```
-pub fn find<T: PartialEq>(p: &[T], u: T) -> usize {
+pub fn find<T>(p: &[T], u: T) -> usize
+    where T: PartialOrd
+{
     for (i, v) in p.iter().enumerate() {
         if *v == u {
             return i;


### PR DESCRIPTION
Motivation behind this is improved readability in source code as well as rust-docs.

It’s much quicker to spot implemented traits (`Mul<Vector<T>>`) and/or the implementing type (`Matrix<T>`) in declarations like the following:

```rust
impl<T> Mul<Vector<T>> for Matrix<T> where T: Copy + Zero + Mul<T, Output=T> + Add<T, Output=T>
```

than is it to spot them in

```rust
impl<T: Copy + Zero + Mul<T, Output=T> + Add<T, Output=T>> Mul<Vector<T>> for Matrix<T>
```

After all we’re usually reading Rust code from left to right.

Also consistency.