### PR TITLE
Rename iterator functions to *_iter

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -16,7 +16,9 @@ impl<T> From<Vec<T>> for Vector<T> {
     }
 }
 
-impl<'a, T> From<&'a [T]> for Vector<T> where T: Clone {
+impl<'a, T> From<&'a [T]> for Vector<T>
+    where T: Clone
+{
     fn from(slice: &'a [T]) -> Self {
         Vector::new(slice.to_owned())
     }
@@ -32,7 +34,7 @@ macro_rules! impl_matrix_from {
     ($slice_type:ident) => {
         impl<'a, T: Copy> From<$slice_type<'a, T>> for Matrix<T> {
             fn from(slice: $slice_type<'a, T>) -> Self {
-                slice.iter_rows().collect::<Matrix<T>>()
+                slice.row_iter().collect::<Matrix<T>>()
             }
         }
     }

--- a/src/matrix/decomposition/bidiagonal.rs
+++ b/src/matrix/decomposition/bidiagonal.rs
@@ -61,9 +61,9 @@ impl<T> Matrix<T>
                 unsafe {
                     // Get the kth row from column k+1 to end.
                     row = std::slice::from_raw_parts(self.data
-                                                    .as_ptr()
-                                                    .offset((k * self.cols + k + 1) as isize),
-                                                n - k - 1);
+                                                         .as_ptr()
+                                                         .offset((k * self.cols + k + 1) as isize),
+                                                     n - k - 1);
                 }
 
                 let row_h_holder = try!(Matrix::make_householder(row).map_err(|_| {
@@ -110,12 +110,8 @@ mod tests {
                        u: &Matrix<f64>,
                        v: &Matrix<f64>,
                        upper: bool) {
-        for (idx, row) in b.iter_rows().enumerate() {
-            let pair_start = if upper {
-                idx
-            } else {
-                idx.saturating_sub(1)
-            };
+        for (idx, row) in b.row_iter().enumerate() {
+            let pair_start = if upper { idx } else { idx.saturating_sub(1) };
             assert!(!row.iter().take(pair_start).any(|&x| x > 1e-10));
             assert!(!row.iter().skip(pair_start + 2).any(|&x| x > 1e-10));
         }

--- a/src/matrix/decomposition/svd.rs
+++ b/src/matrix/decomposition/svd.rs
@@ -322,7 +322,7 @@ mod tests {
 
     fn validate_svd(mat: &Matrix<f64>, b: &Matrix<f64>, u: &Matrix<f64>, v: &Matrix<f64>) {
         // b is diagonal (the singular values)
-        for (idx, row) in b.iter_rows().enumerate() {
+        for (idx, row) in b.row_iter().enumerate() {
             assert!(!row.iter().take(idx).any(|&x| x > 1e-10));
             assert!(!row.iter().skip(idx + 1).any(|&x| x > 1e-10));
             // Assert non-negativity of diagonal elements
@@ -347,7 +347,7 @@ mod tests {
         let ref v_transposed = v.transpose();
         let ref mat_transposed = mat.transpose();
 
-        let mut singular_triplets = u_transposed.iter_rows().zip(b.diag().into_iter()).zip(v_transposed.iter_rows())
+        let mut singular_triplets = u_transposed.row_iter().zip(b.diag().into_iter()).zip(v_transposed.row_iter())
             // chained zipping results in nested tuple. Flatten it.
             .map(|((u_col, singular_value), v_col)| (Vector::new(u_col), singular_value, Vector::new(v_col)));
 

--- a/src/matrix/impl_ops.rs
+++ b/src/matrix/impl_ops.rs
@@ -665,7 +665,7 @@ impl<'a, T> $assign_trt<Matrix<T>> for MatrixSliceMut<'a, T>
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: Matrix<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+        for (slice_row, target_row) in self.row_iter_mut().zip(_rhs.row_iter()) {
             utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
         }
     }
@@ -678,8 +678,8 @@ impl<'a, 'b, T> $assign_trt<&'b Matrix<T>> for MatrixSliceMut<'a, T>
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: &Matrix<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut()
-                                        .zip(_rhs.iter_rows()) {
+        for (slice_row, target_row) in self.row_iter_mut()
+                                        .zip(_rhs.row_iter()) {
             utils::in_place_vec_bin_op(slice_row,
                                         target_row,
                                         |x, &y| {*x = (*x).$op(y) });
@@ -704,8 +704,8 @@ impl<'a, 'b, T> $assign_trt<$target_slice<'b, T>> for MatrixSliceMut<'a, T>
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: $target_slice<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut()
-                                            .zip(_rhs.iter_rows()) {
+        for (slice_row, target_row) in self.row_iter_mut()
+                                            .zip(_rhs.row_iter()) {
             utils::in_place_vec_bin_op(slice_row,
                                         target_row,
                                         |x, &y| {*x = (*x).$op(y) });
@@ -720,8 +720,8 @@ impl<'a, 'b, 'c, T> $assign_trt<&'c $target_slice<'b, T>> for MatrixSliceMut<'a,
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: &$target_slice<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut()
-                                            .zip(_rhs.iter_rows()) {
+        for (slice_row, target_row) in self.row_iter_mut()
+                                            .zip(_rhs.row_iter()) {
             utils::in_place_vec_bin_op(slice_row,
                                         target_row,
                                         |x, &y| {*x = (*x).$op(y) });
@@ -745,7 +745,7 @@ macro_rules! impl_op_assign_mat_slice (
 impl<'a, T> $assign_trt<$target_mat<'a, T>> for Matrix<T>
     where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: $target_mat<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+        for (slice_row, target_row) in self.row_iter_mut().zip(_rhs.row_iter()) {
             utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
         }
     }
@@ -757,7 +757,7 @@ impl<'a, T> $assign_trt<$target_mat<'a, T>> for Matrix<T>
 impl<'a, 'b, T> $assign_trt<&'b $target_mat<'a, T>> for Matrix<T>
     where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: &$target_mat<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+        for (slice_row, target_row) in self.row_iter_mut().zip(_rhs.row_iter()) {
             utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
         }
     }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -574,7 +574,9 @@ impl<T: Any + Float> Matrix<T> {
             let (l, u, p) = match self.lup_decomp() {
                 Ok(x) => x,
                 Err(ref e) if *e.kind() == ErrorKind::DivByZero => return T::zero(),
-                _ => { panic!("Could not compute LUP decomposition."); }
+                _ => {
+                    panic!("Could not compute LUP decomposition.");
+                }
             };
 
             let mut d = T::one();
@@ -632,7 +634,7 @@ impl<'a, T: Float> Metric<T> for MatrixSlice<'a, T> {
     fn norm(&self) -> T {
         let mut s = T::zero();
 
-        for row in self.iter_rows() {
+        for row in self.row_iter() {
             s = s + utils::dot(row, row);
         }
         s.sqrt()
@@ -657,7 +659,7 @@ impl<'a, T: Float> Metric<T> for MatrixSliceMut<'a, T> {
     fn norm(&self) -> T {
         let mut s = T::zero();
 
-        for row in self.iter_rows() {
+        for row in self.row_iter() {
             s = s + utils::dot(row, row);
         }
         s.sqrt()
@@ -738,7 +740,7 @@ fn back_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
           M: BaseMatrix<T>
 {
     if m.is_empty() {
-        return Err(Error::new(ErrorKind::InvalidArg, "Matrix is empty."))
+        return Err(Error::new(ErrorKind::InvalidArg, "Matrix is empty."));
     }
 
     let mut x = vec![T::zero(); y.size()];
@@ -751,9 +753,7 @@ fn back_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
             }
 
             let diag = *m.get_unchecked([i, i]);
-            if diag.abs() < T::min_positive_value() +
-                T::min_positive_value()
-            {
+            if diag.abs() < T::min_positive_value() + T::min_positive_value() {
                 return Err(Error::new(ErrorKind::AlgebraFailure,
                                       "Linear system cannot be solved (matrix is singular)."));
             }
@@ -770,7 +770,7 @@ fn forward_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
           M: BaseMatrix<T>
 {
     if m.is_empty() {
-        return Err(Error::new(ErrorKind::InvalidArg, "Matrix is empty."))
+        return Err(Error::new(ErrorKind::InvalidArg, "Matrix is empty."));
     }
 
     let mut x = Vec::with_capacity(y.size());
@@ -848,15 +848,15 @@ mod tests {
 
     #[test]
     fn test_new_mat_from_fn() {
-      let mut counter = 0;
-      let m : Matrix<usize> = Matrix::from_fn(3, 2, |_, _| {
-        let value = counter;
-        counter += 1;
-        value
-      });
-      assert!(m.rows() == 3);
-      assert!(m.cols() == 2);
-      assert!(m.data == vec![0, 1, 2, 3, 4, 5]);
+        let mut counter = 0;
+        let m: Matrix<usize> = Matrix::from_fn(3, 2, |_, _| {
+            let value = counter;
+            counter += 1;
+            value
+        });
+        assert!(m.rows() == 3);
+        assert!(m.cols() == 2);
+        assert!(m.data == vec![0, 1, 2, 3, 4, 5]);
     }
 
     #[test]


### PR DESCRIPTION
Code has some automatic code formatting. Compilation and all tests are OK.