### PR TITLE
Fixing LU pivot bugs

### DIFF
--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -1,13 +1,39 @@
-use matrix::{Matrix, BaseMatrix};
+use matrix::{Matrix, BaseMatrix, BaseMatrixMut};
 use error::{Error, ErrorKind};
 use utils;
 
 use std::any::Any;
 
-use libnum::{Float};
+use libnum::Float;
 
 impl<T> Matrix<T> where T: Any + Float
 {
+
+    fn produce_pivot(&self) -> Matrix<T> {
+        let n = self.rows();
+
+        let mut p = Matrix::<T>::identity(n);
+
+        // Compute the permutation matrix
+        for i in 0..n {
+            // Find the max value in each column
+            let mut curr_max_idx = i;
+            let mut curr_max = self[[i, i]];
+
+            for j in i+1..n {
+                if self[[j,i]] > curr_max {
+                    curr_max = self[[j,i]];
+                    curr_max_idx = j;
+                }
+            }
+
+            if curr_max_idx != i {
+                p.swap_rows(i, curr_max_idx);
+            }
+        }
+
+        p
+    }
 
     /// Computes L, U, and P for LUP decomposition.
     ///
@@ -38,52 +64,38 @@ impl<T> Matrix<T> where T: Any + Float
 
         let mut l = Matrix::<T>::zeros(n, n);
         let mut u = Matrix::<T>::zeros(n, n);
-
-        let mt = self.transpose();
-
-        let mut p = Matrix::<T>::identity(n);
-
-        // Compute the permutation matrix
-        for i in 0..n {
-            let (row,_) = utils::argmax(&mt.data[i*(n+1)..(i+1)*n]);
-
-            if row != 0 {
-                for j in 0..n {
-                    p.data.swap(i*n + j, row*n+j)
-                }
-            }
-        }
-
+        let p = self.produce_pivot();
         let a_2 = &p * self;
 
         for i in 0..n {
-            l.data[i*(n+1)] = T::one();
+            l[[i, i]] = T::one();
 
             for j in 0..i+1 {
                 let mut s1 = T::zero();
 
                 for k in 0..j {
-                    s1 = s1 + l.data[j*n + k] * u.data[k*n + i];
+                    s1 = s1 + l[[j, k]] * u[[k, i]];
                 }
 
-                u.data[j*n + i] = a_2[[j,i]] - s1;
+                u[[j ,i]] = a_2[[j,i]] - s1;
             }
 
             for j in i..n {
                 let mut s2 = T::zero();
 
                 for k in 0..i {
-                    s2 = s2 + l.data[j*n + k] * u.data[k*n + i];
+                    s2 = s2 + l[[j, k]] * u[[k, i]];
                 }
 
                 let denom = u[[i,i]];
 
-                if denom == T::zero() {
+                if denom.abs() < T::epsilon() {
                     return Err(Error::new(ErrorKind::DivByZero,
                         "Singular matrix found in LUP decomposition. \
                         A value in the diagonal of U == 0.0."));
                 }
-                l.data[j*n + i] = (a_2[[j,i]] - s2) / denom;
+                
+                l[[j, i]] = (a_2[[j,i]] - s2) / denom;
             }
 
         }
@@ -118,5 +130,25 @@ mod tests {
             Err(e) => assert!(*e.kind() == ErrorKind::DivByZero),
             Ok(_) => panic!()
         }
+    }
+
+    #[test]
+    fn test_basic_pivot() {
+        let a = matrix![5f64,4.,3.,2.,1.;
+                        4.,3.,2.,1.,5.;
+                        3.,2.,1.,5.,4.;
+                        2.,1.,5.,4.,3.;
+                        1.,5.,4.,3.,2.];
+        let p = a.produce_pivot();
+
+        let true_p = matrix![1f64,0.,0.,0.,0.;
+                            0.,0.,0.,0.,1.;
+                            0.,0.,0.,1.,0.;
+                            0.,0.,1.,0.,0.;
+                            0.,1.,0.,0.,0.];
+
+        assert!(p.data().iter()
+                    .zip(true_p.data().iter())
+                    .all(|(&x,&y)| (x-y).abs() == 0.0));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -250,7 +250,7 @@ pub fn argmax<T>(u: &[T]) -> (usize, T)
     let mut max_index = 0;
     let mut max = u[max_index];
 
-    for (i, v) in (u.iter()).enumerate() {
+    for (i, v) in u.iter().enumerate().skip(1) {
         if max < *v {
             max_index = i;
             max = *v;
@@ -282,7 +282,7 @@ pub fn argmin<T>(u: &[T]) -> (usize, T)
     let mut min_index = 0;
     let mut min = u[min_index];
 
-    for (i, v) in (u.iter()).enumerate() {
+    for (i, v) in u.iter().enumerate().skip(1) {
         if min > *v {
             min_index = i;
             min = *v;

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -3,6 +3,28 @@ use rulinalg::matrix::Matrix;
 use rulinalg::matrix::slice::BaseMatrix;
 
 #[test]
+fn test_solve() {
+    let a = matrix![-4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+                    1.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+                    0.0, 1.0, -4.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
+                    1.0, 0.0, 0.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0;
+                    0.0, 1.0, 0.0, 1.0, -4.0, 1.0, 0.0, 1.0, 0.0;
+                    0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 0.0, 0.0, 1.0;
+                    0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -4.0, 1.0, 0.0;
+                    0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 1.0;
+                    0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
+
+    let b = Vector::new(vec![-100.0, 0.0, 0.0, -100.0, 0.0, 0.0, -100.0, 0.0, 0.0]);
+
+    let c = a.solve(b).unwrap();
+    let true_solution = vec![42.85714286, 18.75, 7.14285714, 52.67857143,
+                             25.0, 9.82142857, 42.85714286, 18.75, 7.14285714];
+    
+    assert!(c.into_iter().zip(true_solution.into_iter()).all(|(x, y)| (x-y) < 1e-5));
+
+}
+
+#[test]
 fn test_l_triangular_solve_errs() {
     let a: Matrix<f64> = matrix!();
     assert!(a.solve_l_triangular(Vector::new(vec![])).is_err());
@@ -36,18 +58,30 @@ fn matrix_lup_decomp() {
     assert_eq!(*l.data(), l_true);
     assert_eq!(*u.data(), u_true);
 
-    let e = matrix!(1., 2., 3., 4., 5.;
+    let b = matrix!(1., 2., 3., 4., 5.;
                     3., 0., 4., 5., 6.;
                     2., 1., 2., 3., 4.;
                     0., 0., 0., 6., 5.;
                     0., 0., 0., 5., 6.);
 
-    let (l, u, p) = e.lup_decomp().expect("Matrix SHOULD be able to be decomposed...");
+    let (l, u, p) = b.lup_decomp().expect("Matrix SHOULD be able to be decomposed...");
     let k = p.transpose() * l * u;
 
     for i in 0..25 {
-        assert_eq!(e.data()[i], k.data()[i]);
+        assert_eq!(b.data()[i], k.data()[i]);
     }
+
+    let c = matrix![-4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+                    1.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+                    0.0, 1.0, -4.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
+                    1.0, 0.0, 0.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0;
+                    0.0, 1.0, 0.0, 1.0, -4.0, 1.0, 0.0, 1.0, 0.0;
+                    0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 0.0, 0.0, 1.0;
+                    0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -4.0, 1.0, 0.0;
+                    0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 1.0;
+                    0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
+
+    assert!(c.lup_decomp().is_ok());
 }
 
 #[test]


### PR DESCRIPTION
This resolves issue #74 (pending approval from @bright-star ).

There was an issue with the previous pivoting - often times the pivot matrix would not actually pivot correctly (while still producing a valid orthogonal matrix and so not failing in every case). The new pivot technique works directly on the columns which may be slightly less efficient (we also remove a transpose) - but is _more_ correct.