### PR TITLE
Fixed additional lu pivot bugs

### DIFF
--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -40,7 +40,7 @@ impl<T> Matrix<T> where T: Any + Float
             let mut curr_max_idx = index;
             let mut curr_max = u[[curr_max_idx, curr_max_idx]];
 
-            for i in curr_max_idx..n {
+            for i in (curr_max_idx+1)..n {
                 if u[[i, index]].abs() > curr_max.abs() {
                     curr_max = u[[i, index]];
                     curr_max_idx = i;

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -5,44 +5,6 @@ use std::any::Any;
 
 use libnum::Float;
 
-fn lup_decomp<T>(size:usize, l:&mut Matrix<T>, u:&mut Matrix<T>, p:&mut Matrix<T>) -> Result<(), Error> where T: Any + Float {
-    let n = l.rows();
-    if size == 0 {
-        Ok(())
-    } else {
-        let mut curr_max_idx = n-size;
-        let mut curr_max = u[[curr_max_idx, curr_max_idx]];
-
-        for i in curr_max_idx..n {
-            if u[[i, n-size]].abs() > curr_max.abs() {
-                curr_max = u[[i, n-size]];
-                curr_max_idx = i;
-            }
-        }
-        if curr_max.abs() < T::epsilon() {
-            return Err(Error::new(ErrorKind::DivByZero,
-                "Singular matrix found in LUP decomposition. \
-                A value in the diagonal of U == 0.0."));
-        }
-
-        if curr_max_idx != n-size {
-            l.swap_rows(n-size, curr_max_idx);
-            u.swap_rows(n-size, curr_max_idx);
-            p.swap_rows(n-size, curr_max_idx);
-        }
-        l[[n-size, n-size]] = T::one();
-        for i in (n-size+1)..n {
-            let mult = u[[i, n-size]]/curr_max;
-            l[[i, n-size]] = mult;
-            u[[i, n-size]] = T::zero();
-            for j in (n-size+1)..n {
-                u[[i, j]] = u[[i,j]] - mult*u[[n-size, j]];
-            }
-        }
-        lup_decomp(size-1, l, u, p)
-    }
-}
-
 impl<T> Matrix<T> where T: Any + Float
 {
     /// Computes L, U, and P for LUP decomposition.
@@ -73,10 +35,39 @@ impl<T> Matrix<T> where T: Any + Float
         let mut l = Matrix::<T>::zeros(n, n);
         let mut u = self.clone();
         let mut p = Matrix::<T>::identity(n);
-        match lup_decomp(n, &mut l, &mut u, &mut p) {
-            Ok(()) => Ok((l, u, p)),
-            Err(e) => Err(e)
+
+        for index in 0..n {
+            let mut curr_max_idx = index;
+            let mut curr_max = u[[curr_max_idx, curr_max_idx]];
+
+            for i in curr_max_idx..n {
+                if u[[i, index]].abs() > curr_max.abs() {
+                    curr_max = u[[i, index]];
+                    curr_max_idx = i;
+                }
+            }
+            if curr_max.abs() < T::epsilon() {
+                return Err(Error::new(ErrorKind::DivByZero,
+                    "Singular matrix found in LUP decomposition. \
+                    A value in the diagonal of U == 0.0."));
+            }
+
+            if curr_max_idx != index {
+                l.swap_rows(index, curr_max_idx);
+                u.swap_rows(index, curr_max_idx);
+                p.swap_rows(index, curr_max_idx);
+            }
+            l[[index, index]] = T::one();
+            for i in (index+1)..n {
+                let mult = u[[i, index]]/curr_max;
+                l[[i, index]] = mult;
+                u[[i, index]] = T::zero();
+                for j in (index+1)..n {
+                    u[[i, j]] = u[[i,j]] - mult*u[[index, j]];
+                }
+            }
         }
+        Ok((l, u, p))
     }
 }
 

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -1,4 +1,4 @@
-use matrix::{Matrix, BaseMatrix, BaseMatrixMut};
+use matrix::{Matrix, BaseMatrixMut};
 use error::{Error, ErrorKind};
 
 use std::any::Any;
@@ -32,6 +32,7 @@ impl<T> Matrix<T> where T: Any + Float
     /// - Matrix cannot be LUP decomposed.
     pub fn lup_decomp(&self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
         let n = self.cols;
+        assert!(self.rows == n, "Matrix must be square for LUP decomposition.");
         let mut l = Matrix::<T>::zeros(n, n);
         let mut u = self.clone();
         let mut p = Matrix::<T>::identity(n);

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -5,35 +5,46 @@ use std::any::Any;
 
 use libnum::Float;
 
-impl<T> Matrix<T> where T: Any + Float
-{
+fn lup_decomp<T>(size:usize, l:&mut Matrix<T>, u:&mut Matrix<T>, p:&mut Matrix<T>) -> Result<(), Error> where T: Any + Float {
+    let n = l.rows();
+    if size == 0 {
+        Ok(())
+    } else {
+        let mut curr_max_idx = n-size;
+        let mut curr_max = u[[curr_max_idx, curr_max_idx]];
 
-    fn produce_pivot(&self) -> Matrix<T> {
-        let n = self.rows();
-
-        let mut p = Matrix::<T>::identity(n);
-
-        // Compute the permutation matrix
-        for i in 0..n {
-            // Find the max value in each column
-            let mut curr_max_idx = i;
-            let mut curr_max = self[[i, i]];
-
-            for j in i+1..n {
-                if self[[j,i]] > curr_max {
-                    curr_max = self[[j,i]];
-                    curr_max_idx = j;
-                }
-            }
-
-            if curr_max_idx != i {
-                p.swap_rows(i, curr_max_idx);
+        for i in curr_max_idx..n {
+            if u[[i, n-size]].abs() > curr_max.abs() {
+                curr_max = u[[i, n-size]];
+                curr_max_idx = i;
             }
         }
+        if curr_max.abs() < T::epsilon() {
+            return Err(Error::new(ErrorKind::DivByZero,
+                "Singular matrix found in LUP decomposition. \
+                A value in the diagonal of U == 0.0."));
+        }
 
-        p
+        if curr_max_idx != n-size {
+            l.swap_rows(n-size, curr_max_idx);
+            u.swap_rows(n-size, curr_max_idx);
+            p.swap_rows(n-size, curr_max_idx);
+        }
+        l[[n-size, n-size]] = T::one();
+        for i in (n-size+1)..n {
+            let mult = u[[i, n-size]]/curr_max;
+            l[[i, n-size]] = mult;
+            u[[i, n-size]] = T::zero();
+            for j in (n-size+1)..n {
+                u[[i, j]] = u[[i,j]] - mult*u[[n-size, j]];
+            }
+        }
+        lup_decomp(size-1, l, u, p)
     }
+}
 
+impl<T> Matrix<T> where T: Any + Float
+{
     /// Computes L, U, and P for LUP decomposition.
     ///
     /// Returns L,U, and P respectively.
@@ -59,47 +70,13 @@ impl<T> Matrix<T> where T: Any + Float
     /// - Matrix cannot be LUP decomposed.
     pub fn lup_decomp(&self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
         let n = self.cols;
-        assert!(self.rows == n, "Matrix must be square for LUP decomposition.");
-
         let mut l = Matrix::<T>::zeros(n, n);
-        let mut u = Matrix::<T>::zeros(n, n);
-        let p = self.produce_pivot();
-        let a_2 = &p * self;
-
-        for i in 0..n {
-            l[[i, i]] = T::one();
-
-            for j in 0..i+1 {
-                let mut s1 = T::zero();
-
-                for k in 0..j {
-                    s1 = s1 + l[[j, k]] * u[[k, i]];
-                }
-
-                u[[j ,i]] = a_2[[j,i]] - s1;
-            }
-
-            for j in i..n {
-                let mut s2 = T::zero();
-
-                for k in 0..i {
-                    s2 = s2 + l[[j, k]] * u[[k, i]];
-                }
-
-                let denom = u[[i,i]];
-
-                if denom.abs() < T::epsilon() {
-                    return Err(Error::new(ErrorKind::DivByZero,
-                        "Singular matrix found in LUP decomposition. \
-                        A value in the diagonal of U == 0.0."));
-                }
-                
-                l[[j, i]] = (a_2[[j,i]] - s2) / denom;
-            }
-
+        let mut u = self.clone();
+        let mut p = Matrix::<T>::identity(n);
+        match lup_decomp(n, &mut l, &mut u, &mut p) {
+            Ok(()) => Ok((l, u, p)),
+            Err(e) => Err(e)
         }
-
-        Ok((l,u,p))
     }
 }
 
@@ -129,25 +106,5 @@ mod tests {
             Err(e) => assert!(*e.kind() == ErrorKind::DivByZero),
             Ok(_) => panic!()
         }
-    }
-
-    #[test]
-    fn test_basic_pivot() {
-        let a = matrix![5f64,4.,3.,2.,1.;
-                        4.,3.,2.,1.,5.;
-                        3.,2.,1.,5.,4.;
-                        2.,1.,5.,4.,3.;
-                        1.,5.,4.,3.,2.];
-        let p = a.produce_pivot();
-
-        let true_p = matrix![1f64,0.,0.,0.,0.;
-                            0.,0.,0.,0.,1.;
-                            0.,0.,0.,1.,0.;
-                            0.,0.,1.,0.,0.;
-                            0.,1.,0.,0.,0.];
-
-        assert!(p.data().iter()
-                    .zip(true_p.data().iter())
-                    .all(|(&x,&y)| (x-y).abs() == 0.0));
     }
 }

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -82,6 +82,13 @@ fn matrix_lup_decomp() {
                     0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
 
     assert!(c.lup_decomp().is_ok());
+
+    let d = matrix![1.0, 1.0, 0.0, 0.0;
+                    0.0, 0.0, 1.0, 0.0;
+                    -1.0, 0.0, 0.0, 0.0;
+                    0.0, 0.0, 0.0, 1.0];
+
+    assert!(d.lup_decomp().is_ok());
 }
 
 #[test]


### PR DESCRIPTION
I was having some issues with .solve; the lu decomposition failed for some simple matrices that had obvious solutions (I added the smallest one to the lu test.) It turns out that there were still lingering bugs in the pivot selection code. It didn't take into account that the optimal pivot for a given column can be changed by previous steps in the decomposition, which in some cases meant that the selected pivot was zero while other candidates were non-zero. I fixed the problem by computing the pivot matrix at the same time as the lower and upper matrices.

It seems to work, but you might want to check it just to be sure - I had to change the entire decomposition method.