### PR TITLE
LU rewrite, first draft

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,9 @@ pub enum ErrorKind {
     /// Tried to divide by zero
     DivByZero,
     /// Failure due to inability to convert between scalar types
-    ScalarConversionFailure
+    ScalarConversionFailure,
+    /// A user-supplied permutation is not a valid permutation.
+    InvalidPermutation
 }
 
 impl Error {

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -145,7 +145,7 @@ impl<T> LuDecomposition<T> where T: Any + Float {
             let y = try!(self.solve(e));
 
             for j in 0 .. n {
-                inv[[i, j]] = y[j];
+                inv[[j, i]] = y[j];
             }
 
             e = Vector::zeros(n);
@@ -234,6 +234,21 @@ mod tests {
         let inv = lu.inverse().expect("Matrix is invertible.");
 
         assert_matrix_eq!(inv, Matrix::identity(3), comp = float);
+    }
+
+    #[test]
+    pub fn lu_inverse_arbitrary_matrix() {
+        let x = matrix![5.0, 0.0, 0.0, 1.0;
+                        2.0, 2.0, 2.0, 1.0;
+                        4.0, 5.0, 5.0, 5.0;
+                        1.0, 6.0, 4.0, 5.0];
+
+        let inv = matrix![1.85185185185185203e-01,   1.85185185185185175e-01, -7.40740740740740561e-02, -1.02798428206033007e-17;
+                          1.66666666666666630e-01,   6.66666666666666519e-01, -6.66666666666666519e-01,  4.99999999999999833e-01;
+                         -3.88888888888888840e-01,   1.11111111111111174e-01,  5.55555555555555358e-01, -4.99999999999999833e-01;
+                          7.40740740740740838e-02,  -9.25925925925925819e-01,  3.70370370370370294e-01,  5.13992141030165006e-17];
+
+        assert_matrix_eq!(inv, x.lu().inverse().unwrap(), comp = float);
     }
 
     #[test]

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -1,15 +1,44 @@
-use matrix::{Matrix, BaseMatrixMut};
+use matrix::{Matrix, BaseMatrixMut, forward_substitution, back_substitution};
+use vector::Vector;
 use error::{Error};
+use matrix::Decomposition;
 
 use std::any::Any;
 
 use libnum::Float;
 
-impl<T> Matrix<T> where T: Any + Float
-{
+/// The L, U and P matrices in the LUP decomposition.
+#[derive(Debug, Clone)]
+pub struct LU<T> {
+    /// The lower triangular matrix in the LUP decomposition.
+    pub l: Matrix<T>,
+    /// The upper triangular matrix in the LUP decomposition.
+    pub u: Matrix<T>,
+    /// The permutation matrix in the LUP decomposition.
+    pub p: Matrix<T>
+}
+
+/// TODO
+#[derive(Debug, Clone)]
+pub struct LuDecomposition<T> {
+    // For now, we store the separate factors, but in the future
+    // we can greatly reduce memory usage by storing both L and U
+    // in the space of a single matrix
+    lu: LU<T>
+}
+
+impl<T> Decomposition for LuDecomposition<T> {
+    type Factors = LU<T>;
+
+    fn decompose(self) -> Self::Factors {
+        self.lu
+    }
+}
+
+impl<T> Matrix<T> where T: Any + Float {
     /// Computes the LUP decomposition.
     ///
-    /// For a given square matrix `A`, returns `(L, U, P)` such that
+    /// For a given square matrix `A`, returns L, U, P such that
     ///
     /// ```text
     /// PA = LU
@@ -21,27 +50,23 @@ impl<T> Matrix<T> where T: Any + Float
     /// # Examples
     ///
     /// ```
-    /// use rulinalg::matrix::Matrix;
+    /// use rulinalg::matrix::{Matrix, Decomposition, LU};
     ///
     /// let a = Matrix::new(3,3, vec![1.0, 2.0, 0.0,
     ///                               0.0, 3.0, 4.0,
     ///                               5.0, 1.0, 2.0]);
     ///
-    /// let (l,u,p) = a.lup_decomp().expect("This matrix should decompose!");
+    /// let LU { l, u, p } = a.lu().decompose();
     /// ```
     ///
     /// # Panics
     ///
     /// - Matrix is not square.
-    ///
-    /// # Failures
-    ///
-    /// - Can not fail. `Result` will be removed in future releases.
-    pub fn lup_decomp(&self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
+    pub fn lu(self) -> LuDecomposition<T> {
         let n = self.cols;
         assert!(self.rows == n, "Matrix must be square for LUP decomposition.");
         let mut l = Matrix::<T>::zeros(n, n);
-        let mut u = self.clone();
+        let mut u = self;
         let mut p = Matrix::<T>::identity(n);
 
         for index in 0..n {
@@ -78,20 +103,37 @@ impl<T> Matrix<T> where T: Any + Float
                 }
             }
         }
-        Ok((l, u, p))
+
+        LuDecomposition {
+            lu: LU {
+                l: l,
+                u: u,
+                p: p
+            }
+        }
+    }
+}
+
+
+impl<T> LuDecomposition<T> where T: Any + Float {
+    /// TODO
+    pub fn solve(&self, b: Vector<T>) -> Result<Vector<T>, Error> {
+        let b = try!(forward_substitution(&self.lu.l, &self.lu.p * b));
+        back_substitution(&self.lu.u, b)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use matrix::Matrix;
+    use matrix::{Matrix, Decomposition};
+    use matrix::LU;
 
     #[test]
     #[should_panic]
     fn test_non_square_lup_decomp() {
         let a: Matrix<f64> = Matrix::ones(2, 3);
 
-        let _ = a.lup_decomp();
+        let _ = a.lu();
     }
 
     #[test]
@@ -111,7 +153,7 @@ mod tests {
             let x = matrix![2.0, 5.0, 3.0;
                             0.0, 0.0, 1.0;
                             0.0, 0.0, 3.0];
-            let (l, u, p) = x.lup_decomp().unwrap();
+            let LU { l, u, p } = x.clone().lu().decompose();
             assert_matrix_eq!(x, p.transpose() * l * u, comp = float);
         }
 
@@ -119,7 +161,7 @@ mod tests {
             let x = matrix![2.0, 0.0, 0.0;
                             5.0, 0.0, 0.0;
                             3.0, 1.0, 3.0];
-            let (l, u, p) = x.lup_decomp().unwrap();
+            let LU { l, u, p } = x.clone().lu().decompose();
             assert_matrix_eq!(x, p.transpose() * l * u, comp = float);
         }
 
@@ -127,7 +169,7 @@ mod tests {
             let x = matrix![1.0, 2.0, 3.0;
                             3.0, 2.0, 1.0;
                             4.0, 4.0, 4.0];
-            let (l, u, p) = x.lup_decomp().unwrap();
+            let LU { l, u, p } = x.clone().lu().decompose();
             assert_matrix_eq!(x, p.transpose() * l * u, comp = float);
         }
     }

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -174,6 +174,7 @@ mod tests {
     use super::LuDecomposition;
     use matrix::{Matrix, Decomposition};
     use matrix::LU;
+    use libnum::Float;
 
     #[test]
     #[should_panic]
@@ -237,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    pub fn lu_inverse_arbitrary_matrix() {
+    pub fn lu_inverse_arbitrary_invertible_matrix() {
         let x = matrix![5.0, 0.0, 0.0, 1.0;
                         2.0, 2.0, 2.0, 1.0;
                         4.0, 5.0, 5.0, 5.0;
@@ -252,6 +253,15 @@ mod tests {
     }
 
     #[test]
+    pub fn lu_inverse_arbitrary_singular_matrix() {
+        let x = matrix![ 5.0,  0.0,  0.0,  1.0;
+                         0.0,  2.0,  2.0,  1.0;
+                        15.0,  4.0,  4.0, 10.0;
+                         5.0,  2.0,  2.0, 32.0];
+        assert!(x.lu().inverse().is_err());
+    }
+
+    #[test]
     pub fn lu_det_identity() {
         let lu = LuDecomposition::<f64> {
             lu: LU {
@@ -261,9 +271,28 @@ mod tests {
             }
         };
 
-        let det = lu.det();
+        assert_eq!(lu.det(), 1.0);
+    }
 
-        assert_eq!(det, 1.0);
+    #[test]
+    pub fn lu_det_arbitrary_invertible_matrix() {
+        let x = matrix![ 5.0,  0.0,  0.0,  1.0;
+                         0.0,  2.0,  2.0,  1.0;
+                        15.0,  4.0,  7.0, 10.0;
+                         5.0,  2.0, 17.0, 32.0];
+
+        let expected_det = 149.99999999999997;
+        let diff = x.lu().det() - expected_det;
+        assert!(diff.abs() < 1e-12);
+    }
+
+    #[test]
+    pub fn lu_det_arbitrary_singular_matrix() {
+        let x = matrix![ 5.0,  0.0,  0.0,  1.0;
+                         0.0,  2.0,  2.0,  1.0;
+                        15.0,  4.0,  4.0, 10.0;
+                         5.0,  2.0,  2.0, 32.0];
+        assert_eq!(x.lu().det(), 0.0);
     }
 
     #[test]
@@ -272,10 +301,9 @@ mod tests {
                          4.0,  3.0,  2.0, -3.0;
                          1.0, -1.0,  4.0, -5.0;
                          4.0,  3.0,  2.0,  5.0];
-        // This works now, but changes to the algorithms may
-        // perturb the determinant just enough for an exact comparison
-        // to fail. Should really use some kind of approximate floating point
-        // comparison here...
-        assert_eq!(x.lu().det(), 56.0);
+
+        let expected_det = 56.0;
+        let diff = x.lu().det() - expected_det;
+        assert!(diff.abs() < 1e-13);
     }
 }

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -18,6 +18,8 @@ mod hessenberg;
 mod lu;
 mod eigen;
 
+pub use self::lu::{LU, LuDecomposition};
+
 use std::any::Any;
 
 use matrix::{Matrix};
@@ -27,6 +29,15 @@ use utils;
 use error::{Error, ErrorKind};
 
 use libnum::{Float};
+
+/// TODO
+pub trait Decomposition {
+    /// TODO
+    type Factors;
+
+    /// TODO
+    fn decompose(self) -> Self::Factors;
+}
 
 impl<T> Matrix<T>
     where T: Any + Float

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -20,6 +20,7 @@ mod decomposition;
 mod impl_ops;
 mod mat_mul;
 mod iter;
+mod permutation_matrix;
 pub mod slice;
 
 pub use self::slice::{BaseMatrix, BaseMatrixMut};
@@ -28,6 +29,8 @@ pub use self::decomposition::{
     LU,
     LuDecomposition
 };
+
+pub use self::permutation_matrix::{PermutationMatrix};
 
 /// Matrix dimensions
 #[derive(Debug, Clone, Copy)]

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -23,6 +23,11 @@ mod iter;
 pub mod slice;
 
 pub use self::slice::{BaseMatrix, BaseMatrixMut};
+pub use self::decomposition::{
+    Decomposition,
+    LU,
+    LuDecomposition
+};
 
 /// Matrix dimensions
 #[derive(Debug, Clone, Copy)]
@@ -459,10 +464,7 @@ impl<T: Any + Float> Matrix<T> {
     /// - The matrix cannot be decomposed into an LUP form to solve.
     /// - There is no valid solution as the matrix is singular.
     pub fn solve(&self, y: Vector<T>) -> Result<Vector<T>, Error> {
-        let (l, u, p) = try!(self.lup_decomp());
-
-        let b = try!(forward_substitution(&l, p * y));
-        back_substitution(&u, b)
+        self.clone().lu().solve(y)
     }
 
     /// Computes the inverse of the matrix.
@@ -492,10 +494,7 @@ impl<T: Any + Float> Matrix<T> {
         assert!(self.rows == self.cols, "Matrix is not square.");
 
         let mut inv_t_data = Vec::<T>::new();
-        let (l, u, p) = try!(self.lup_decomp().map_err(|_| {
-            Error::new(ErrorKind::DecompFailure,
-                       "Could not compute LUP factorization for inverse.")
-        }));
+        let LU { l, u, p } = self.clone().lu().decompose();
 
         let mut d = T::one();
 
@@ -571,11 +570,7 @@ impl<T: Any + Float> Matrix<T> {
             (self[[0, 1]] * self[[1, 0]] * self[[2, 2]]) -
             (self[[0, 2]] * self[[1, 1]] * self[[2, 0]])
         } else {
-            let (l, u, p) = match self.lup_decomp() {
-                Ok(x) => x,
-                Err(ref e) if *e.kind() == ErrorKind::DivByZero => return T::zero(),
-                _ => { panic!("Could not compute LUP decomposition."); }
-            };
+            let LU { l, u, p } = self.clone().lu().decompose();
 
             let mut d = T::one();
 

--- a/src/matrix/permutation_matrix.rs
+++ b/src/matrix/permutation_matrix.rs
@@ -1,0 +1,36 @@
+// use matrix::BaseMatrixMut;
+// use std::ops::Mul;
+// use std::any::Any;
+use std;
+
+/// TODO
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PermutationMatrix<T> {
+    // An N x N permutation matrix P can be seen as a map
+    // { 1, ..., N } -> { 1, ..., N }
+    // Hence, we merely store N indices, such that
+    // perm[[i]] = j
+    // means that index i is mapped to index j
+    perm: Vec<usize>,
+
+    // Currently, we need to let PermutationMatrix be generic over T,
+    // because BaseMatrixMut is.
+    marker: std::marker::PhantomData<T>
+}
+
+impl<T> PermutationMatrix<T> {
+    /// The identity permutation.
+    pub fn identity(n: usize) -> Self {
+        PermutationMatrix {
+            perm: (0 .. n).collect(),
+            marker: std::marker::PhantomData
+        }
+    }
+
+    /// Swaps indices i and j
+    pub fn swap(&mut self, i: usize, j: usize) {
+        self.perm.swap(i, j);
+    }
+
+    // pub fn inverse(...)
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! Contains support methods for linear algebra structs.
 
+mod permutation;
+pub use self::permutation::Permutation;
+
+
 use std::cmp;
 use libnum::Zero;
 use std::ops::{Add, Mul, Sub, Div};

--- a/src/utils/permutation.rs
+++ b/src/utils/permutation.rs
@@ -1,0 +1,266 @@
+use error::{Error, ErrorKind};
+
+/// An abstract permutation of an ordered set.
+///
+/// Given an ordered set X of cardinality N, `Permutation` is an efficient representation
+/// of a permutation of this set. More concretely, if X is an array,
+/// it maps each index to a new (unique) index in the permuted array.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Permutation {
+    // Represents a permutation map
+    // { 1, ..., N } -> { 1, ..., N }
+    // For each index in the vector,
+    perm: Vec<usize>
+}
+
+impl Permutation {
+    /// The cardinality of the sets that the permutation can be applied to.
+    ///
+    /// If the permutation permutes sets of cardinality `N`, then `cardinality()` is equal to `N`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::utils::Permutation;
+    ///
+    /// let p = Permutation::identity(4);
+    /// assert_eq!(p.cardinality(), 4);
+    /// ```
+    pub fn cardinality(&self) -> usize {
+        self.perm.len()
+    }
+
+    /// Returns the identity permutation.
+    ///
+    /// That is, it returns the unique permutation such that
+    /// when applied to an ordered set X yields X itself.
+    pub fn identity(n: usize) -> Self {
+        Permutation {
+            perm: (0 .. n).collect()
+        }
+    }
+
+    /// Swaps indices in the permutation.
+    ///
+    /// If P sends `i` to `a`, and `j` to `b`,
+    /// then P sends `i` to `b` and `j` to `a` after this operation.
+    pub fn swap(&mut self, i: usize, j: usize) {
+        self.perm.swap(i, j);
+    }
+
+    /// Maps an index from the original set to the permuted set.
+    ///
+    /// If the permutation P sends `i` to `j`, then this function
+    /// returns `j`.
+    pub fn map_index(&self, i: usize) -> usize {
+        self.perm[i]
+    }
+
+    /// Constructs a `Permutation` from an array.
+    ///
+    /// # Errors
+    /// The supplied N-length array must satisfy the following:
+    ///
+    /// - Each element must be in the half-open range [0, N).
+    /// - Each element must be unique.
+    pub fn from_array<A: Into<Vec<usize>>>(array: A) -> Result<Permutation, Error> {
+        let p = Permutation::from_array_unchecked(array);
+        validate_permutation(&p.perm).map(|_| p)
+    }
+
+    /// Constructs a `Permutation` from an array, without checking the validity of
+    /// the supplied permutation.
+    ///
+    /// However, to ease development, a `debug_assert` with regards to the validity
+    /// is still performed.
+    ///
+    /// Use of this function is generally discouraged unless the checked version
+    /// has been proven to be a performance bottleneck.
+    pub fn from_array_unchecked<A: Into<Vec<usize>>>(array: A) -> Permutation {
+        let p = Permutation {
+            perm: array.into()
+        };
+        debug_assert!(validate_permutation(&p.perm).is_ok(), "Permutation is not valid");
+        p
+    }
+
+    /// Applies the permutation by swapping elements in an abstract
+    /// container.
+    ///
+    /// The permutation is applied by calls to `swap(i, j)` for indices
+    /// `i` and `j`.
+    ///
+    /// # Complexity
+    ///
+    /// - O(1) memory usage.
+    /// - O(n) worst case number of calls to `swap`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::utils::Permutation;
+    ///
+    /// let p = Permutation::from_array(vec![1, 0, 2]).unwrap();
+    /// let mut x = vec![0, 1, 2];
+    /// p.permute_by_swap(|i, j| x.swap(i, j));
+    ///
+    /// assert_eq!(x, vec![1, 0, 2]);
+    /// ```
+    pub fn permute_by_swap<S>(mut self, mut swap: S) where S: FnMut(usize, usize) -> () {
+        // Please see https://en.wikipedia.org/wiki/Cyclic_permutation
+        // for some explanation to the terminology used here.
+        // Some useful resources I found on the internet:
+        //
+        // https://blog.merovius.de/2014/08/12/applying-permutation-in-constant.html
+        // http://stackoverflow.com/questions/16501424/algorithm-to-apply-permutation-in-constant-memory-space
+        //
+        // A fundamental property of permutations on finite sets is that
+        // any such permutation can be decomposed into a collection of
+        // cycles on disjoint orbits.
+        //
+        // An observation is thus that given a permutation P,
+        // we can trace out the cycle that includes index i
+        // by starting at i and moving to P[i] recursively.
+        for i in 0 .. self.perm.len() {
+            let mut target = self.perm[i];
+            while i != target {
+                // When resolving a cycle, we resolve each index in the cycle
+                // by repeatedly moving the current item into the target position,
+                // and item in the target position into the current position.
+                // By repeating this until we hit the start index,
+                // we effectively resolve the entire cycle.
+                let new_target = self.perm[target];
+                swap(i, target);
+                self.perm[target] = target;
+                target = new_target;
+            }
+            self.perm[i] = i;
+        }
+    }
+
+    /// The inverse of this permutation.
+    ///
+    /// More precisely, if the current permutation `perm` sends index i to j, then
+    /// `perm.inverse()` sends j to i.
+    pub fn inverse(&self) -> Permutation {
+        let mut inv: Vec<usize> = vec![0; self.cardinality()];
+
+        for (source, target) in self.perm.iter().cloned().enumerate() {
+            inv[target] = source;
+        }
+
+        Permutation {
+            perm: inv
+        }
+    }
+}
+
+impl From<Permutation> for Vec<usize> {
+    fn from(p: Permutation) -> Vec<usize> {
+        p.perm
+    }
+}
+
+fn validate_permutation(perm: &[usize]) -> Result<(), Error> {
+    use std::collections::HashSet;
+
+    let ref n = perm.len();
+    let all_in_bounds = perm.iter().all(|x| x < n);
+
+    // Note: If we ever use itertools, this could be replaced with a one-liner.
+    let all_unique = {
+        let mut visited = HashSet::new();
+        let mut unique = true;
+        for i in perm {
+            if visited.contains(&i) {
+                unique = false;
+                break;
+            }
+            visited.insert(i);
+        }
+        unique
+    };
+
+    if !all_in_bounds && !all_unique {
+        Err(Error::new(ErrorKind::InvalidPermutation,
+            "Supplied permutation array has both elements out of bounds and duplicate elements."))
+    } else if !all_in_bounds {
+        Err(Error::new(ErrorKind::InvalidPermutation,
+            "Supplied permutation array has elements out of bounds."))
+    } else if !all_unique {
+        Err(Error::new(ErrorKind::InvalidPermutation,
+            "Supplied permutation array duplicate elements."))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Permutation;
+
+    #[test]
+    fn permutation_permute_by_swap_on_empty_array() {
+        let mut x = Vec::<char>::new();
+        let p = Permutation::from_array(Vec::new()).unwrap();
+        p.permute_by_swap(|i, j| x.swap(i, j));
+    }
+
+    #[test]
+    fn permutation_permute_by_swap_on_arbitrary_array() {
+        let mut x = vec!['a', 'b', 'c', 'd'];
+        let p = Permutation::from_array(vec![0, 2, 3, 1]).unwrap();
+
+        p.clone().permute_by_swap(|i, j| x.swap(i, j));
+        assert_eq!(x, vec!['a', 'd', 'b', 'c']);
+    }
+
+    #[test]
+    fn permutation_permute_by_swap_identity_on_arbitrary_array() {
+        let mut x = vec!['a', 'b', 'c', 'd'];
+        let p = Permutation::from_array(vec![0, 1, 2, 3]).unwrap();
+        p.clone().permute_by_swap(|i, j| x.swap(i, j));
+        assert_eq!(x, vec!['a', 'b', 'c', 'd']);
+    }
+
+    #[test]
+    fn permutation_into_vec() {
+        let index_map = vec![0, 2, 3, 1];
+        let p = Permutation::from_array(index_map.clone()).unwrap();
+        let p_as_vec: Vec<usize> = p.into();
+        assert_eq!(index_map, p_as_vec);
+    }
+
+    #[test]
+    fn permutation_cardinality() {
+        let p = Permutation::from_array(vec![0, 2, 1]).unwrap();
+        assert_eq!(p.cardinality(), 3);
+    }
+
+    #[test]
+    fn permutation_mapped_index() {
+        let p = Permutation::from_array(vec![0, 2, 1]).unwrap();
+        assert_eq!(p.map_index(0), 0);
+        assert_eq!(p.map_index(1), 2);
+        assert_eq!(p.map_index(2), 1);
+    }
+
+    #[test]
+    fn permutation_swap() {
+        let mut p = Permutation::from_array(vec![0, 2, 1]).unwrap();
+
+        p.swap(1, 2);
+        assert_eq!(Vec::from(p.clone()), vec![0, 1, 2]);
+
+        p.swap(0, 2);
+        assert_eq!(Vec::from(p), vec![2, 1, 0]);
+    }
+
+    #[test]
+    fn permutation_from_array_if_invalid() {
+        assert!(Permutation::from_array(vec![1]).is_err());
+        assert!(Permutation::from_array(vec![0, 0]).is_err());
+        assert!(Permutation::from_array(vec![0, 1, 1]).is_err());
+        assert!(Permutation::from_array(vec![0, 2]).is_err());
+    }
+}

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -1,5 +1,5 @@
 use rulinalg::vector::Vector;
-use rulinalg::matrix::Matrix;
+use rulinalg::matrix::{Matrix, LU, Decomposition};
 use rulinalg::matrix::slice::BaseMatrix;
 
 #[test]
@@ -19,7 +19,7 @@ fn test_solve() {
     let c = a.solve(b).unwrap();
     let true_solution = vec![42.85714286, 18.75, 7.14285714, 52.67857143,
                              25.0, 9.82142857, 42.85714286, 18.75, 7.14285714];
-    
+
     assert!(c.into_iter().zip(true_solution.into_iter()).all(|(x, y)| (x-y) < 1e-5));
 
 }
@@ -48,7 +48,7 @@ fn matrix_lup_decomp() {
                     2., 4., 7.;
                     1., 1., 0.);
 
-    let (l, u, p) = a.lup_decomp().expect("Matrix SHOULD be able to be decomposed...");
+    let LU { l, u, p } = a.lu().decompose();
 
     let l_true = vec![1., 0., 0., 0.5, 1., 0., 0.5, -1., 1.];
     let u_true = vec![2., 4., 7., 0., 1., 1.5, 0., 0., -2.];
@@ -64,31 +64,28 @@ fn matrix_lup_decomp() {
                     0., 0., 0., 6., 5.;
                     0., 0., 0., 5., 6.);
 
-    let (l, u, p) = b.lup_decomp().expect("Matrix SHOULD be able to be decomposed...");
-    let k = p.transpose() * l * u;
+    let LU { l, u, p } = b.clone().lu().decompose();
+    assert_matrix_eq!(b, p.transpose() * l * u);
 
-    for i in 0..25 {
-        assert_eq!(b.data()[i], k.data()[i]);
-    }
+    // TODO: Fix these tests to take the new API into account
+    // let c = matrix![-4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    //                 1.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+    //                 0.0, 1.0, -4.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
+    //                 1.0, 0.0, 0.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0;
+    //                 0.0, 1.0, 0.0, 1.0, -4.0, 1.0, 0.0, 1.0, 0.0;
+    //                 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 0.0, 0.0, 1.0;
+    //                 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -4.0, 1.0, 0.0;
+    //                 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 1.0;
+    //                 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
 
-    let c = matrix![-4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
-                    1.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0;
-                    0.0, 1.0, -4.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
-                    1.0, 0.0, 0.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0;
-                    0.0, 1.0, 0.0, 1.0, -4.0, 1.0, 0.0, 1.0, 0.0;
-                    0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 0.0, 0.0, 1.0;
-                    0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -4.0, 1.0, 0.0;
-                    0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 1.0;
-                    0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
+    // assert!(c.lup_decomp().is_ok());
 
-    assert!(c.lup_decomp().is_ok());
+    // let d = matrix![1.0, 1.0, 0.0, 0.0;
+    //                 0.0, 0.0, 1.0, 0.0;
+    //                 -1.0, 0.0, 0.0, 0.0;
+    //                 0.0, 0.0, 0.0, 1.0];
 
-    let d = matrix![1.0, 1.0, 0.0, 0.0;
-                    0.0, 0.0, 1.0, 0.0;
-                    -1.0, 0.0, 0.0, 0.0;
-                    0.0, 0.0, 0.0, 1.0];
-
-    assert!(d.lup_decomp().is_ok());
+    // assert!(d.lup_decomp().is_ok());
 }
 
 #[test]


### PR DESCRIPTION
This is by no means finished, but I wanted to give contributors an opportunity to weigh in with some opinions, if anyone wants to.

In line with some of the ideas discussed in #40, I've recently started to put together a redesign of the LU decomposition. If we reach concencus on the ideas put forth, I plan to do a similar redesign of the other decompositions.

Currently, the LU(P) decomposition as implemented in `rulinalg` simply returns a triplet of the three matrices `L`, `U` and `P`. One of the strengths of the LU decomposition, is that once decomposed, one can very efficiently solve many linear systems `Ax = b` where the matrix `A` is constant, but `b` varies. It would thus be convenient if this functionality was readily available and optimized through rulinalg's API. Thus, I propose to instead let the decomposition return a specialized type that makes this operation easier.

In addition, returning all three matrices is not optimal in terms of storage space. In particular, one can store the L and U matrices in the space of a single matrix, rather than two separate matrices, halving the memory costs. This is not yet implemented in this PR, but it's possible to implement without breaking changes.

Finally, I want to implement a custom `PermutationMatrix` structure. Currently the permutation matrix is returned as a full `Matrix<T>`, but by its nature, a permutation matrix needs only `O(n)` storage, and it can be applied much more efficiently than performing a full matrix-matrix or matrix-vector application. This is also not yet implemented in this PR.

I've also made one more important change: for whatever reason, the LUP decomposition that is currently implemented fails if the matrix is singular. However, there always exists an LUP decomposition for _any_ square matrix, so I've taken this into account, and as such we no longer need to return a `Result` for the decomposition itself.

In short, we currently write:
```rust
let a: Matrix<T> = ...;
// Perform LUP decomp in O(n^3) operations
let (l, u, p) = a.lup_decomp().expect("Should work?");

// Solving Ax = b in O(n^2) operations with the LU decomposition
// is somewhat convoluted
let y = l.solve_l_triangular(P * b).expect("Matrix is invertible")
let x = u.solve_u_triangular(y).expect("Matrix is invertible");
```

With the proposed changes, we have instead:

```rust
let a: Matrix<T> = ...;
// Consumes the matrix and returns an opaque decomposition object
// in O(n^3) operations
let lu = a.lu();

// Solve Ax = b in O(n^2) operations. The details of the operation are
// conveniently abstracted away from the user, and we can heavily
// optimize it if need be.
let x = lu.solve(b).expect("Matrix is invertible");

// Can compute determinant in O(n) operations
let det = lu.det();

// Finally, can consume the decomposition to obtain
// the individual matrices
let LU { l, u, p } = lu.decompose();
```

Note the last line in the previous example. I've explicitly avoided returning a triplet here, because it's very easy to mess up the order. In rulinalg we have (l, u, p), but i.e. NumPy returns (p, l, u). I even made this mistake once when working with the previous API. These sort of errors can be very frustrating if they are not quickly discovered! Of course, with the above struct deconstructing API, the call is order-independent, so the last line could have been replaced with `LU { p, l, u }` or `LU { u, p, l }` without having any effect on the behavior of the code.