### PR TITLE
Implement NumCast-based try_into

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -5,7 +5,9 @@
 
 use std::convert::From;
 
-use libnum::Zero;
+use libnum::{Zero, ToPrimitive, NumCast};
+
+use error::{Error, ErrorKind};
 
 use super::matrix::{DiagOffset, Matrix, MatrixSlice, MatrixSliceMut, BaseMatrix};
 use super::vector::Vector;
@@ -64,6 +66,25 @@ impl_diag_offset_from!(i32);
 impl_diag_offset_from!(i64);
 impl_diag_offset_from!(isize);
 
+impl<T: ToPrimitive> Matrix<T> {
+    /// Attempts to convert the matrix into a new matrix of different scalar type.
+    ///
+    /// # Failures
+    /// - One or more of the elements in the matrix cannot be converted into
+    ///   the new type.
+    pub fn try_into<U: NumCast>(self) -> Result<Matrix<U>, Error> {
+        let (m, n) = (self.rows(), self.cols());
+        let ref make_error = || Error::new(ErrorKind::ScalarConversionFailure,
+                                       "Failed to convert between scalar types.");
+        let converted_data = self.into_vec()
+                                 .into_iter()
+                                 .map(|x| U::from(x).ok_or_else(make_error))
+                                 .collect::<Result<Vec<_>, Error>>();
+
+        Ok(Matrix::<U>::new(m, n, try!(converted_data)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use matrix::{DiagOffset, Matrix, MatrixSlice, MatrixSliceMut, BaseMatrix};
@@ -107,6 +128,138 @@ mod tests {
         assert_eq!(a, DiagOffset::Below(3));
         let a: DiagOffset = 0.into();
         assert_eq!(a, DiagOffset::Main);
+    }
+
+    #[test]
+    fn try_into_empty_matrix() {
+        {
+            let x: Matrix<f64> = matrix![];
+            let y: Matrix<f32> = x.try_into().unwrap();
+            assert_matrix_eq!(y, matrix![]);
+        }
+
+        {
+            let x: Matrix<u64> = matrix![];
+            let y: Matrix<u32> = x.try_into().unwrap();
+            assert_matrix_eq!(y, matrix![]);
+        }
+
+        {
+            let x: Matrix<f64> = matrix![];
+            let y: Matrix<u64> = x.try_into().unwrap();
+            assert_matrix_eq!(y, matrix![]);
+        }
+
+        {
+            let x: Matrix<u8>  = matrix![];
+            let y: Matrix<u64> = x.try_into().unwrap();
+            assert_matrix_eq!(y, matrix![]);
+        }
+    }
+
+    #[test]
+    fn try_into_f64_to_i64() {
+        let x: Matrix<f64> = matrix![ 1.0, 2.0;
+                                     -3.0, 4.0];
+        let y: Matrix<i64> = x.try_into().unwrap();
+        let expected = matrix![ 1, 2;
+                               -3, 4];
+        assert_matrix_eq!(y, expected);
+    }
+
+    #[test]
+    fn try_into_f64_to_u64() {
+        let x: Matrix<f64> = matrix![ 1.0, 2.0;
+                                      3.0, 4.0];
+        let y: Matrix<u64> = x.try_into().unwrap();
+        let expected = matrix![ 1, 2;
+                                3, 4];
+        assert_matrix_eq!(y, expected);
+    }
+
+    #[test]
+    fn try_into_i64_to_f64() {
+        {
+            let x: Matrix<i64> = matrix![ 1, 2;
+                                         -3, 4];
+            let y: Matrix<f64> = x.try_into().unwrap();
+
+            let expected = matrix![ 1.0, 2.0;
+                                   -3.0, 4.0];
+            assert_matrix_eq!(y, expected);
+        }
+
+        {
+            // Recall that f64 cannot exactly represent integers of sufficiently
+            // large absolute value. Yet, Rust will cast and round as necessary,
+            // so we only check that the result is Ok.
+            {
+                let x: Matrix<i64> = matrix![ 1, 2, i64::max_value()];
+                let y_result = x.try_into::<f64>();
+                assert!(y_result.is_ok());
+            }
+
+            {
+                let x: Matrix<i64> = matrix![ 1, 2, i64::min_value()];
+                let y_result = x.try_into::<f64>();
+                assert!(y_result.is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn try_into_u64_to_f64() {
+        {
+            let x: Matrix<u64> = matrix![ 1, 2;
+                                          3, 4];
+            let y: Matrix<f64> = x.try_into().unwrap();
+
+            let expected = matrix![ 1.0, 2.0;
+                                    3.0, 4.0];
+            assert_matrix_eq!(y, expected);
+        }
+
+        {
+            // Recall that f64 cannot exactly represent integers of sufficiently
+            // large absolute value. Yet, Rust will cast and round as necessary,
+            // so we only check that the result is Ok.
+            {
+                let x: Matrix<u64> = matrix![ 1, 2, u64::max_value()];
+                let y_result = x.try_into::<f64>();
+                assert!(y_result.is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn try_into_signed_unsigned() {
+        {
+            let x: Matrix<u64> = matrix![ 1, 2;
+                                          3, 4];
+            let y: Matrix<i64> = x.try_into().unwrap();
+
+            let expected = matrix![ 1, 2;
+                                    3, 4];
+            assert_matrix_eq!(y, expected);
+        }
+
+        {
+            let x: Matrix<i64> = matrix![ 1, 2;
+                                          3, 4];
+            let y: Matrix<u64> = x.try_into().unwrap();
+
+            let expected = matrix![ 1, 2;
+                                    3, 4];
+            assert_matrix_eq!(y, expected);
+        }
+
+        {
+            // Cannot cast negative values into unsigned
+            let x = matrix![ 1, -2;
+                             3,  4];
+            let y_result = x.try_into::<u64>();
+            assert!(y_result.is_err());
+        }
     }
 
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,9 @@ pub enum ErrorKind {
     /// A failure due to some algebraic constraints not being met.
     AlgebraFailure,
     /// Tried to divide by zero
-    DivByZero
+    DivByZero,
+    /// Failure due to inability to convert between scalar types
+    ScalarConversionFailure
 }
 
 impl Error {


### PR DESCRIPTION
Need this functionality for writing some interesting QuickCheck-based property tests for the LU Decomposition, so in the process I made an attempt to resolve #79.

As @AtheMathmo stated in the issue, the better long-term solution would be to implement `TryFrom/TryInto` once they are stabilized.

Since the functionality relies on `NumCast`, the tests only try to test a small sample of the possible conversions, and also corner cases like empty matrices. Please let me know if there are corner cases I should include!