### PR TITLE
Updating get_row functions to return MatrixSlice

### DIFF
--- a/src/matrix/decomposition/svd.rs
+++ b/src/matrix/decomposition/svd.rs
@@ -326,7 +326,7 @@ mod tests {
             assert!(!row.iter().take(idx).any(|&x| x > 1e-10));
             assert!(!row.iter().skip(idx + 1).any(|&x| x > 1e-10));
             // Assert non-negativity of diagonal elements
-            assert!(row[idx] >= 0.0);
+            assert!(row.raw_slice()[idx] >= 0.0);
         }
 
         let recovered = u * b * v.transpose();
@@ -349,7 +349,7 @@ mod tests {
 
         let mut singular_triplets = u_transposed.iter_rows().zip(b.diag().into_iter()).zip(v_transposed.iter_rows())
             // chained zipping results in nested tuple. Flatten it.
-            .map(|((u_col, singular_value), v_col)| (Vector::new(u_col), singular_value, Vector::new(v_col)));
+            .map(|((u_col, singular_value), v_col)| (Vector::new(u_col.raw_slice()), singular_value, Vector::new(v_col.raw_slice())));
 
         assert!(singular_triplets.by_ref()
             // For a matrix M, each singular value σ and left and right singular vectors u and v respectively

--- a/src/matrix/decomposition/svd.rs
+++ b/src/matrix/decomposition/svd.rs
@@ -326,6 +326,7 @@ mod tests {
             assert!(!row.iter().take(idx).any(|&x| x > 1e-10));
             assert!(!row.iter().skip(idx + 1).any(|&x| x > 1e-10));
             // Assert non-negativity of diagonal elements
+            // TODO: Fix when indexing fixed
             assert!(row.raw_slice()[idx] >= 0.0);
         }
 

--- a/src/matrix/decomposition/svd.rs
+++ b/src/matrix/decomposition/svd.rs
@@ -327,7 +327,7 @@ mod tests {
             assert!(!row.iter().skip(idx + 1).any(|&x| x > 1e-10));
             // Assert non-negativity of diagonal elements
             // TODO: Fix when indexing fixed
-            assert!(row.raw_slice()[idx] >= 0.0);
+            assert!(row[idx] >= 0.0);
         }
 
         let recovered = u * b * v.transpose();

--- a/src/matrix/decomposition/svd.rs
+++ b/src/matrix/decomposition/svd.rs
@@ -326,7 +326,6 @@ mod tests {
             assert!(!row.iter().take(idx).any(|&x| x > 1e-10));
             assert!(!row.iter().skip(idx + 1).any(|&x| x > 1e-10));
             // Assert non-negativity of diagonal elements
-            // TODO: Fix when indexing fixed
             assert!(row[idx] >= 0.0);
         }
 

--- a/src/matrix/deref.rs
+++ b/src/matrix/deref.rs
@@ -1,0 +1,48 @@
+use super::{MatrixSlice, MatrixSliceMut};
+use super::{Row, RowMut, Column, ColumnMut};
+
+use std::ops::{Deref, DerefMut};
+
+impl<'a, T: 'a> Deref for Row<'a, T> {
+    type Target = MatrixSlice<'a, T>;
+
+    fn deref(&self) -> &MatrixSlice<'a, T> {
+        &self.row
+    }
+}
+
+impl<'a, T: 'a> Deref for RowMut<'a, T> {
+    type Target = MatrixSliceMut<'a, T>;
+
+    fn deref(&self) -> &MatrixSliceMut<'a, T> {
+        &self.row
+    }
+}
+
+impl<'a, T: 'a> DerefMut for RowMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut MatrixSliceMut<'a, T> {
+        &mut self.row
+    }
+}
+
+impl<'a, T: 'a> Deref for Column<'a, T> {
+    type Target = MatrixSlice<'a, T>;
+
+    fn deref(&self) -> &MatrixSlice<'a, T> {
+        &self.col
+    }
+}
+
+impl<'a, T: 'a> Deref for ColumnMut<'a, T> {
+    type Target = MatrixSliceMut<'a, T>;
+
+    fn deref(&self) -> &MatrixSliceMut<'a, T> {
+        &self.col
+    }
+}
+
+impl<'a, T: 'a> DerefMut for ColumnMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut MatrixSliceMut<'a, T> {
+        &mut self.col
+    }
+}

--- a/src/matrix/impl_ops.rs
+++ b/src/matrix/impl_ops.rs
@@ -665,8 +665,10 @@ impl<'a, T> $assign_trt<Matrix<T>> for MatrixSliceMut<'a, T>
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: Matrix<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
-            utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
+        for (mut slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+            utils::in_place_vec_bin_op(slice_row.raw_slice_mut(),
+                                        target_row.raw_slice(),
+                                        |x, &y| {*x = (*x).$op(y) });
         }
     }
 }
@@ -678,10 +680,10 @@ impl<'a, 'b, T> $assign_trt<&'b Matrix<T>> for MatrixSliceMut<'a, T>
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: &Matrix<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut()
+        for (mut slice_row, target_row) in self.iter_rows_mut()
                                         .zip(_rhs.iter_rows()) {
-            utils::in_place_vec_bin_op(slice_row,
-                                        target_row,
+            utils::in_place_vec_bin_op(slice_row.raw_slice_mut(),
+                                        target_row.raw_slice(),
                                         |x, &y| {*x = (*x).$op(y) });
         }
     }
@@ -704,10 +706,10 @@ impl<'a, 'b, T> $assign_trt<$target_slice<'b, T>> for MatrixSliceMut<'a, T>
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: $target_slice<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut()
+        for (mut slice_row, target_row) in self.iter_rows_mut()
                                             .zip(_rhs.iter_rows()) {
-            utils::in_place_vec_bin_op(slice_row,
-                                        target_row,
+            utils::in_place_vec_bin_op(slice_row.raw_slice_mut(),
+                                        target_row.raw_slice(),
                                         |x, &y| {*x = (*x).$op(y) });
         }
     }
@@ -720,10 +722,10 @@ impl<'a, 'b, 'c, T> $assign_trt<&'c $target_slice<'b, T>> for MatrixSliceMut<'a,
     where T: Copy + $trt<T, Output=T>
 {
     fn $op_assign(&mut self, _rhs: &$target_slice<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut()
+        for (mut slice_row, target_row) in self.iter_rows_mut()
                                             .zip(_rhs.iter_rows()) {
-            utils::in_place_vec_bin_op(slice_row,
-                                        target_row,
+            utils::in_place_vec_bin_op(slice_row.raw_slice_mut(),
+                                        target_row.raw_slice(),
                                         |x, &y| {*x = (*x).$op(y) });
         }
     }
@@ -745,8 +747,10 @@ macro_rules! impl_op_assign_mat_slice (
 impl<'a, T> $assign_trt<$target_mat<'a, T>> for Matrix<T>
     where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: $target_mat<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
-            utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
+        for (mut slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+            utils::in_place_vec_bin_op(slice_row.raw_slice_mut(),
+                                        target_row.raw_slice(),
+                                        |x, &y| {*x = (*x).$op(y) });
         }
     }
 }
@@ -757,8 +761,10 @@ impl<'a, T> $assign_trt<$target_mat<'a, T>> for Matrix<T>
 impl<'a, 'b, T> $assign_trt<&'b $target_mat<'a, T>> for Matrix<T>
     where T: Copy + $trt<T, Output=T> {
     fn $op_assign(&mut self, _rhs: &$target_mat<T>) {
-        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
-            utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
+        for (mut slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+            utils::in_place_vec_bin_op(slice_row.raw_slice_mut(),
+                                        target_row.raw_slice(),
+                                        |x, &y| {*x = (*x).$op(y) });
         }
     }
 }

--- a/src/matrix/impl_ops.rs
+++ b/src/matrix/impl_ops.rs
@@ -1,6 +1,5 @@
-use super::Matrix;
-use super::MatrixSlice;
-use super::MatrixSliceMut;
+use super::{Matrix, MatrixSlice, MatrixSliceMut};
+use super::{Row, RowMut, Column, ColumnMut};
 use super::slice::{BaseMatrix, BaseMatrixMut};
 
 use super::super::utils;
@@ -76,6 +75,46 @@ impl<T> IndexMut<[usize; 2]> for Matrix<T> {
                 "Column index is greater than column dimension.");
         let self_cols = self.cols;
         unsafe { self.data.get_unchecked_mut(idx[0] * self_cols + idx[1]) }
+    }
+}
+
+impl<'a, T> Index<usize> for Row<'a, T> {
+    type Output = T;
+    fn index(&self, idx: usize) -> &T {
+        &self.row[[0, idx]]
+    }
+}
+
+impl<'a, T> Index<usize> for RowMut<'a, T> {
+    type Output = T;
+    fn index(&self, idx: usize) -> &T {
+        &self.row[[0, idx]]
+    }
+}
+
+impl<'a, T> IndexMut<usize> for RowMut<'a, T> {
+    fn index_mut(&mut self, idx: usize) -> &mut T {
+        &mut self.row[[0, idx]]
+    }
+}
+
+impl<'a, T> Index<usize> for Column<'a, T> {
+    type Output = T;
+    fn index(&self, idx: usize) -> &T {
+        &self.col[[idx, 0]]
+    }
+}
+
+impl<'a, T> Index<usize> for ColumnMut<'a, T> {
+    type Output = T;
+    fn index(&self, idx: usize) -> &T {
+        &self.col[[idx, 0]]
+    }
+}
+
+impl<'a, T> IndexMut<usize> for ColumnMut<'a, T> {
+    fn index_mut(&mut self, idx: usize) -> &mut T {
+        &mut self.col[[idx, 0]]
     }
 }
 

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -86,6 +86,7 @@ impl<'a, T> Iterator for $rows<'a, T> {
             unsafe {
 // Get pointer and create a slice from raw parts
                 let ptr = self.slice_start.offset(self.row_pos as isize * self.row_stride);
+                // TODO: Remove after benching
                 //row = slice::$slice_from_parts(ptr, self.slice_cols);
                 row = $row_base {
                     row: $slice_base::from_raw_parts(ptr, 1, self.slice_cols, self.row_stride as usize)
@@ -105,6 +106,7 @@ impl<'a, T> Iterator for $rows<'a, T> {
             unsafe {
 // Get pointer to last row and create a slice from raw parts
                 let ptr = self.slice_start.offset((self.slice_rows - 1) as isize * self.row_stride);
+                // TODO: Remove after benching
                 //Some(slice::$slice_from_parts(ptr, self.slice_cols))
                 Some($row_base {
                     row: $slice_base::from_raw_parts(ptr, 1, self.slice_cols, self.row_stride as usize)
@@ -120,6 +122,7 @@ impl<'a, T> Iterator for $rows<'a, T> {
             let row: $row_type;
             unsafe {
                 let ptr = self.slice_start.offset((self.row_pos + n) as isize * self.row_stride);
+                // TODO: Remove after benching
                 //row = slice::$slice_from_parts(ptr, self.slice_cols);
                 row = $row_base {
                     row: $slice_base::from_raw_parts(ptr, 1, self.slice_cols, self.row_stride as usize)
@@ -144,6 +147,7 @@ impl<'a, T> Iterator for $rows<'a, T> {
     );
 );
 
+// TODO: Remove after benching
 // impl_iter_rows!(Rows, &'a [T], from_raw_parts);
 // impl_iter_rows!(RowsMut, &'a mut [T], from_raw_parts_mut);
 impl_iter_rows!(Rows, Row<'a, T>, Row, MatrixSlice);
@@ -184,6 +188,7 @@ impl<'a, T> ExactSizeIterator for RowsMut<'a, T> {}
 /// // where the first entry is less than 6.
 /// let b = a.iter_rows()
 ///          .skip(1)
+///          // TODO: Fix when indexing implemented
 ///          .filter(|x| x.raw_slice()[0] < 6)
 ///          .collect::<Matrix<usize>>();
 ///

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -268,7 +268,7 @@ impl<'a, T: 'a + Copy> FromIterator<$row_type> for Matrix<T> {
         }
 
         for row in iterator {
-            assert!(row.row.cols() == cols, "Iterator slice length must be constant.");
+            assert!(row.row.cols() == cols, "Iterator row size must be constant.");
             mat_data.extend_from_slice(row.raw_slice());
             rows += 1;
         }

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -2,7 +2,8 @@ use std::iter::{ExactSizeIterator, FromIterator};
 use std::mem;
 use std::slice;
 
-use super::{Matrix, MatrixSlice, MatrixSliceMut, Rows, RowsMut, Diagonal, DiagonalMut};
+use super::{Matrix, MatrixSlice, MatrixSliceMut};
+use super::{Row, RowMut, Rows, RowsMut, Diagonal, DiagonalMut};
 use super::slice::{BaseMatrix, BaseMatrixMut, SliceIter, SliceIterMut};
 
 

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -86,8 +86,6 @@ impl<'a, T> Iterator for $rows<'a, T> {
             unsafe {
 // Get pointer and create a slice from raw parts
                 let ptr = self.slice_start.offset(self.row_pos as isize * self.row_stride);
-                // TODO: Remove after benching
-                //row = slice::$slice_from_parts(ptr, self.slice_cols);
                 row = $row_base {
                     row: $slice_base::from_raw_parts(ptr, 1, self.slice_cols, self.row_stride as usize)
                 };
@@ -106,8 +104,6 @@ impl<'a, T> Iterator for $rows<'a, T> {
             unsafe {
 // Get pointer to last row and create a slice from raw parts
                 let ptr = self.slice_start.offset((self.slice_rows - 1) as isize * self.row_stride);
-                // TODO: Remove after benching
-                //Some(slice::$slice_from_parts(ptr, self.slice_cols))
                 Some($row_base {
                     row: $slice_base::from_raw_parts(ptr, 1, self.slice_cols, self.row_stride as usize)
                 })
@@ -122,8 +118,6 @@ impl<'a, T> Iterator for $rows<'a, T> {
             let row: $row_type;
             unsafe {
                 let ptr = self.slice_start.offset((self.row_pos + n) as isize * self.row_stride);
-                // TODO: Remove after benching
-                //row = slice::$slice_from_parts(ptr, self.slice_cols);
                 row = $row_base {
                     row: $slice_base::from_raw_parts(ptr, 1, self.slice_cols, self.row_stride as usize)
                 }
@@ -147,9 +141,6 @@ impl<'a, T> Iterator for $rows<'a, T> {
     );
 );
 
-// TODO: Remove after benching
-// impl_iter_rows!(Rows, &'a [T], from_raw_parts);
-// impl_iter_rows!(RowsMut, &'a mut [T], from_raw_parts_mut);
 impl_iter_rows!(Rows, Row<'a, T>, Row, MatrixSlice);
 impl_iter_rows!(RowsMut, RowMut<'a, T>, RowMut, MatrixSliceMut);
 
@@ -188,8 +179,7 @@ impl<'a, T> ExactSizeIterator for RowsMut<'a, T> {}
 /// // where the first entry is less than 6.
 /// let b = a.iter_rows()
 ///          .skip(1)
-///          // TODO: Fix when indexing implemented
-///          .filter(|x| x.raw_slice()[0] < 6)
+///          .filter(|x| x[0] < 6)
 ///          .collect::<Matrix<usize>>();
 ///
 /// // We take the middle rows

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -6,6 +6,7 @@
 //! Most of the logic for manipulating matrices is generically implemented
 //! via `BaseMatrix` and `BaseMatrixMut` trait.
 
+use std;
 use std::any::Any;
 use std::fmt;
 use std::marker::PhantomData;
@@ -20,6 +21,7 @@ mod decomposition;
 mod impl_ops;
 mod mat_mul;
 mod iter;
+mod deref;
 pub mod slice;
 
 pub use self::slice::{BaseMatrix, BaseMatrixMut};
@@ -73,6 +75,57 @@ pub struct MatrixSliceMut<'a, T: 'a> {
     marker: PhantomData<&'a mut T>,
 }
 
+/// Row of a matrix.
+///
+/// This struct points to a slice making up
+/// a row in a matrix. You can deref this
+/// struct to retrieve a `MatrixSlice` of
+/// the row.
+///
+/// TODO: Deref example
+#[derive(Debug)]
+pub struct Row<'a, T: 'a> {
+    row: MatrixSlice<'a, T>
+}
+
+/// Mutable row of a matrix.
+///
+/// This struct points to a mutable slice
+/// making up a row in a matrix. You can deref
+/// this struct to retrieve a `MatrixSlice`
+/// of the row.
+///
+/// TODO: Deref example
+#[derive(Debug)]
+pub struct RowMut<'a, T: 'a> {
+    row: MatrixSliceMut<'a, T>
+}
+
+impl<'a, T: 'a> Row<'a, T> {
+    /// Returns the row as a slice.
+    pub fn raw_slice(&self) -> &'a [T] {
+        unsafe {
+            std::slice::from_raw_parts(self.row.as_ptr(), self.row.cols())
+        }
+    }
+}
+
+impl<'a, T: 'a> RowMut<'a, T> {
+    /// Returns the row as a slice.
+    pub fn raw_slice(&self) -> &'a [T] {
+        unsafe {
+            std::slice::from_raw_parts(self.row.as_ptr(), self.row.cols())
+        }
+    }
+
+    /// Returns the row as a slice.
+    pub fn raw_slice_mut(&mut self) -> &'a mut [T] {
+        unsafe {
+            std::slice::from_raw_parts_mut(self.row.as_mut_ptr(), self.row.cols())
+        }
+    }
+}
+
 /// Row iterator.
 #[derive(Debug)]
 pub struct Rows<'a, T: 'a> {
@@ -93,6 +146,32 @@ pub struct RowsMut<'a, T: 'a> {
     slice_cols: usize,
     row_stride: isize,
     _marker: PhantomData<&'a mut T>,
+}
+
+/// Column of a matrix.
+///
+/// This struct points to a `MatrixSlice`
+/// making up a column in a matrix.
+/// You can deref this struct to retrieve
+/// the raw column `MatrixSlice`.
+///
+/// TODO: Deref example
+#[derive(Debug)]
+pub struct Column<'a, T: 'a> {
+    col: MatrixSlice<'a, T>
+}
+
+/// Mutable column of a matrix.
+///
+/// This struct points to a `MatrixSliceMut`
+/// making up a column in a matrix.
+/// You can deref this struct to retrieve
+/// the raw column `MatrixSliceMut`.
+///
+/// TODO: Deref example
+#[derive(Debug)]
+pub struct ColumnMut<'a, T: 'a> {
+    col: MatrixSliceMut<'a, T>
 }
 
 /// Diagonal offset (used by Diagonal iterator).

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -101,6 +101,11 @@ pub struct RowMut<'a, T: 'a> {
     row: MatrixSliceMut<'a, T>
 }
 
+
+//
+// MAYBE WE SHOULD MOVE SOME OF THIS STUFF OUT
+//
+
 impl<'a, T: 'a> Row<'a, T> {
     /// Returns the row as a slice.
     pub fn raw_slice(&self) -> &'a [T] {
@@ -712,7 +717,8 @@ impl<'a, T: Float> Metric<T> for MatrixSlice<'a, T> {
         let mut s = T::zero();
 
         for row in self.iter_rows() {
-            s = s + utils::dot(row, row);
+            let raw_slice = row.raw_slice();
+            s = s + utils::dot(raw_slice, raw_slice);
         }
         s.sqrt()
     }
@@ -737,7 +743,8 @@ impl<'a, T: Float> Metric<T> for MatrixSliceMut<'a, T> {
         let mut s = T::zero();
 
         for row in self.iter_rows() {
-            s = s + utils::dot(row, row);
+            let raw_slice = row.raw_slice();
+            s = s + utils::dot(raw_slice, raw_slice);
         }
         s.sqrt()
     }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -811,7 +811,12 @@ fn parity<T, M>(m: &M) -> T
             while !visited[next] {
                 len += 1;
                 visited[next] = true;
-                next = utils::find(&m.get_row(next).unwrap(), T::one());
+                unsafe {
+                    next = utils::find(&m.get_row_unchecked(next)
+                                    .as_contiguous_slice()
+                                    .unwrap(),
+                                T::one());
+                }
             }
 
             if len % 2 == 0 {

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -91,7 +91,7 @@ pub struct MatrixSliceMut<'a, T: 'a> {
 /// let mat = matrix![1.0, 2.0;
 ///                   3.0, 4.0];
 ///
-/// let row = mat.row(1).unwrap();
+/// let row = mat.row(1);
 /// assert_eq!((*row + 2.0).sum(), 11.0);
 /// # }
 /// ```
@@ -114,10 +114,10 @@ pub struct Row<'a, T: 'a> {
 /// use rulinalg::matrix::BaseMatrixMut;
 ///
 /// let mut mat = matrix![1.0, 2.0;
-///                   3.0, 4.0];
+///                       3.0, 4.0];
 ///
 /// {
-///     let mut row = mat.row_mut(1).unwrap();
+///     let mut row = mat.row_mut(1);
 ///     *row += 2.0;
 /// }
 /// let expected = matrix![1.0, 2.0;
@@ -198,7 +198,7 @@ pub struct RowsMut<'a, T: 'a> {
 /// let mat = matrix![1.0, 2.0;
 ///                   3.0, 4.0];
 ///
-/// let col = mat.col(1).unwrap();
+/// let col = mat.col(1);
 /// assert_eq!((*col + 2.0).sum(), 10.0);
 /// # }
 /// ```
@@ -223,7 +223,7 @@ pub struct Column<'a, T: 'a> {
 /// let mut mat = matrix![1.0, 2.0;
 ///                   3.0, 4.0];
 /// {
-///     let mut column = mat.col_mut(1).unwrap();
+///     let mut column = mat.col_mut(1);
 ///     *column += 2.0;
 /// }
 /// let expected = matrix![1.0, 4.0;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -812,7 +812,7 @@ fn parity<T, M>(m: &M) -> T
                 len += 1;
                 visited[next] = true;
                 unsafe {
-                    next = utils::find(&m.get_row_unchecked(next)
+                    next = utils::find(&m.row_unchecked(next)
                                     .as_contiguous_slice()
                                     .unwrap(),
                                 T::one());

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -82,8 +82,20 @@ pub struct MatrixSliceMut<'a, T: 'a> {
 /// struct to retrieve a `MatrixSlice` of
 /// the row.
 ///
-/// TODO: Deref example
-#[derive(Debug)]
+/// # Example
+///
+/// ```
+/// # #[macro_use] extern crate rulinalg; fn main() {
+/// use rulinalg::matrix::BaseMatrix;
+///
+/// let mat = matrix![1.0, 2.0;
+///                   3.0, 4.0];
+///
+/// let row = mat.row(1).unwrap();
+/// assert_eq!((*row + 2.0).sum(), 11.0);
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy)]
 pub struct Row<'a, T: 'a> {
     row: MatrixSlice<'a, T>
 }
@@ -95,7 +107,24 @@ pub struct Row<'a, T: 'a> {
 /// this struct to retrieve a `MatrixSlice`
 /// of the row.
 ///
-/// TODO: Deref example
+/// # Example
+///
+/// ```
+/// # #[macro_use] extern crate rulinalg; fn main() {
+/// use rulinalg::matrix::BaseMatrixMut;
+///
+/// let mut mat = matrix![1.0, 2.0;
+///                   3.0, 4.0];
+///
+/// {
+///     let mut row = mat.row_mut(1).unwrap();
+///     *row += 2.0;
+/// }
+/// let expected = matrix![1.0, 2.0;
+///                        5.0, 6.0];
+/// assert_matrix_eq!(mat, expected);
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct RowMut<'a, T: 'a> {
     row: MatrixSliceMut<'a, T>
@@ -160,8 +189,20 @@ pub struct RowsMut<'a, T: 'a> {
 /// You can deref this struct to retrieve
 /// the raw column `MatrixSlice`.
 ///
-/// TODO: Deref example
-#[derive(Debug)]
+/// # Example
+///
+/// ```
+/// # #[macro_use] extern crate rulinalg; fn main() {
+/// use rulinalg::matrix::BaseMatrix;
+///
+/// let mat = matrix![1.0, 2.0;
+///                   3.0, 4.0];
+///
+/// let col = mat.col(1).unwrap();
+/// assert_eq!((*col + 2.0).sum(), 10.0);
+/// # }
+/// ```
+#[derive(Debug, Clone, Copy)]
 pub struct Column<'a, T: 'a> {
     col: MatrixSlice<'a, T>
 }
@@ -173,7 +214,23 @@ pub struct Column<'a, T: 'a> {
 /// You can deref this struct to retrieve
 /// the raw column `MatrixSliceMut`.
 ///
-/// TODO: Deref example
+/// # Example
+///
+/// ```
+/// # #[macro_use] extern crate rulinalg; fn main() {
+/// use rulinalg::matrix::BaseMatrixMut;
+///
+/// let mut mat = matrix![1.0, 2.0;
+///                   3.0, 4.0];
+/// {
+///     let mut column = mat.col_mut(1).unwrap();
+///     *column += 2.0;
+/// }
+/// let expected = matrix![1.0, 4.0;
+///                        3.0, 6.0];
+/// assert_matrix_eq!(mat, expected);
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct ColumnMut<'a, T: 'a> {
     col: MatrixSliceMut<'a, T>

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -892,8 +892,7 @@ fn parity<T, M>(m: &M) -> T
                 visited[next] = true;
                 unsafe {
                     next = utils::find(&m.row_unchecked(next)
-                                    .as_contiguous_slice()
-                                    .unwrap(),
+                                    .raw_slice(),
                                 T::one());
                 }
             }

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -82,24 +82,26 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate rulinalg;
-    ///
-    /// # fn main() {
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let col = mat.col(1).unwrap();
+    /// let mat = matrix![0, 1, 2;
+    ///                   3, 4, 5;
+    ///                   6, 7, 8];
+    /// let col = mat.col(1);
     /// let expected = matrix![1usize; 4; 7];
     /// assert_matrix_eq!(*col, expected);
-    /// assert!(mat.col(5).is_none());
     /// # }
     /// ```
-    fn col(&self, index: usize) -> Option<Column<T>> {
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the column index is out of bounds.
+    fn col(&self, index: usize) -> Column<T> {
         if index < self.cols() {
-            unsafe { Some(self.col_unchecked(index)) }
+            unsafe { self.col_unchecked(index) }
         } else {
-            None
+            panic!("Column index out of bounds.")
         }
     }
 
@@ -109,13 +111,12 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate rulinalg;
-    ///
-    /// # fn main() {
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mat = matrix![0, 1, 2;
+    ///                   3, 4, 5;
+    ///                   6, 7, 8];
     /// let col = unsafe { mat.col_unchecked(2) };
     /// let expected = matrix![2usize; 5; 8];
     /// assert_matrix_eq!(*col, expected);
@@ -132,29 +133,30 @@ pub trait BaseMatrix<T>: Sized {
     }
 
     /// Returns the row of a matrix at the given index.
-    /// `None` if the index is out of bounds.
     ///
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate rulinalg;
-    ///
-    /// # fn main() {
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let row = mat.row(1).unwrap();
+    /// let mat = matrix![0, 1, 2;
+    ///                   3, 4, 5;
+    ///                   6, 7, 8];
+    /// let row = mat.row(1);
     /// let expected = matrix![3usize, 4, 5];
     /// assert_matrix_eq!(*row, expected);
-    /// assert!(mat.row(5).is_none());
     /// # }
     /// ```
-    fn row(&self, index: usize) -> Option<Row<T>> {
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the row index is out of bounds.
+    fn row(&self, index: usize) -> Row<T> {
         if index < self.rows() {
-            unsafe { Some(self.row_unchecked(index)) }
+            unsafe { self.row_unchecked(index) }
         } else {
-            None
+            panic!("Row index out of bounds.")
         }
     }
 
@@ -163,13 +165,12 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use]
-    /// # extern crate rulinalg;
-    ///
-    /// # fn main() {
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mat = matrix![0, 1, 2;
+    ///                   3, 4, 5;
+    ///                   6, 7, 8];
     /// let row = unsafe { mat.row_unchecked(2) };
     /// let expected = matrix![6usize, 7, 8];
     /// assert_matrix_eq!(*row, expected);
@@ -190,13 +191,17 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let slice = a.sub_slice([1,1], 2, 2);
+    /// let mat = matrix![0, 1, 2;
+    ///                   3, 4, 5;
+    ///                   6, 7, 8];
+    /// let slice = mat.sub_slice([1,1], 2, 2);
     ///
     /// let slice_data = slice.iter().map(|v| *v).collect::<Vec<usize>>();
     /// assert_eq!(slice_data, vec![4,5,7,8]);
+    /// # }
     /// ```
     fn iter<'a>(&self) -> SliceIter<'a, T>
         where T: 'a
@@ -972,21 +977,26 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// # fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrixMut};
     ///
-    /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut mat = matrix![0, 1, 2;
+    ///                       3, 4, 5;
+    ///                       6, 7, 8];
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
     /// {
-    ///     let col = slice.col_mut(1).unwrap();
+    ///     let col = slice.col_mut(1);
     ///     let mut expected = matrix![5usize; 8];
     ///     assert_matrix_eq!(*col, expected);
     /// }
-    /// assert!(slice.col_mut(5).is_none());
     /// # }
     /// ```
-    fn col_mut(&mut self, index: usize) -> Option<ColumnMut<T>> {
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the column index is out of bounds.
+    fn col_mut(&mut self, index: usize) -> ColumnMut<T> {
         if index < self.cols() {
-            unsafe { Some(self.col_unchecked_mut(index)) }
+            unsafe { self.col_unchecked_mut(index) }
         } else {
-            None
+            panic!("Column index out of bounds.")
         }
     }
 
@@ -1002,7 +1012,9 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// # fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrixMut};
     ///
-    /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut mat = matrix![0, 1, 2;
+    ///                       3, 4, 5;
+    ///                       6, 7, 8];
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
     /// let col = unsafe { slice.col_unchecked_mut(1) };
     /// let mut expected = matrix![5usize; 8];
@@ -1031,21 +1043,26 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// # fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrixMut};
     ///
-    /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut mat = matrix![0, 1, 2;
+    ///                       3, 4, 5;
+    ///                       6, 7, 8];
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
     /// {
-    ///     let row = slice.row_mut(1).unwrap();
+    ///     let row = slice.row_mut(1);
     ///     let mut expected = matrix![7usize, 8];
     ///     assert_matrix_eq!(*row, expected);
     /// }
-    /// assert!(slice.row_mut(5).is_none());
     /// # }
     /// ```
-    fn row_mut(&mut self, index: usize) -> Option<RowMut<T>> {
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the row index is out of bounds.
+    fn row_mut(&mut self, index: usize) -> RowMut<T> {
         if index < self.rows() {
-            unsafe { Some(self.row_unchecked_mut(index)) }
+            unsafe { self.row_unchecked_mut(index) }
         } else {
-            None
+            panic!("Row index out of bounds.")
         }
     }
 
@@ -1061,7 +1078,9 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// # fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrixMut};
     ///
-    /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
+    /// let mut mat = matrix![0, 1, 2;
+    ///                       3, 4, 5;
+    ///                       6, 7, 8];
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
     /// let row = unsafe { slice.row_unchecked_mut(1) };
     /// let mut expected = matrix![7usize, 8];

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -921,19 +921,6 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
         }
     }
 
-    /// TODO: actual documentation
-    ///
-    /// I'm not a fan of this function at all right now.
-    fn as_mut_contiguous_slice(&mut self) -> Option<&mut [T]> {
-        if self.rows() == 1 {
-            unsafe {
-                Some(::std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.cols()))
-            }
-        } else {
-            None
-        }
-    }
-
     /// Get a mutable reference to a point in the matrix without bounds checks.
     unsafe fn get_unchecked_mut(&mut self, index: [usize; 2]) -> &mut T {
         &mut *(self.as_mut_ptr().offset((index[0] * self.row_stride() + index[1]) as isize))

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -1523,6 +1523,84 @@ impl<'a, T> BaseMatrixMut<T> for MatrixSliceMut<'a, T> {
     }
 }
 
+impl<'a, T> BaseMatrix<T> for Row<'a, T> {
+    fn rows(&self) -> usize {
+        1
+    }
+    fn cols(&self) -> usize {
+        self.row.cols()
+    }
+    fn row_stride(&self) -> usize {
+        self.row.row_stride()
+    }
+
+    fn as_ptr(&self) -> *const T {
+        self.row.as_ptr()
+    }
+}
+
+impl<'a, T> BaseMatrix<T> for RowMut<'a, T> {
+    fn rows(&self) -> usize {
+        1
+    }
+    fn cols(&self) -> usize {
+        self.row.cols()
+    }
+    fn row_stride(&self) -> usize {
+        self.row.row_stride()
+    }
+
+    fn as_ptr(&self) -> *const T {
+        self.row.as_ptr()
+    }
+}
+
+impl<'a, T> BaseMatrixMut<T> for RowMut<'a, T> {
+    /// Top left index of the slice.
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.row.as_mut_ptr()
+    }
+}
+
+impl<'a, T> BaseMatrix<T> for Column<'a, T> {
+    fn rows(&self) -> usize {
+        self.col.rows()
+    }
+    fn cols(&self) -> usize {
+        1
+    }
+    fn row_stride(&self) -> usize {
+        self.col.row_stride()
+    }
+
+    fn as_ptr(&self) -> *const T {
+        self.col.as_ptr()
+    }
+}
+
+impl<'a, T> BaseMatrix<T> for ColumnMut<'a, T> {
+    fn rows(&self) -> usize {
+        self.col.rows()
+    }
+    fn cols(&self) -> usize {
+        1
+    }
+    fn row_stride(&self) -> usize {
+        self.col.row_stride()
+    }
+
+    fn as_ptr(&self) -> *const T {
+        self.col.as_ptr()
+    }
+}
+
+impl<'a, T> BaseMatrixMut<T> for ColumnMut<'a, T> {
+    /// Top left index of the slice.
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.col.as_mut_ptr()
+    }
+}
+
 impl<'a, T> MatrixSlice<'a, T> {
     /// Produce a `MatrixSlice` from a `Matrix`
     ///

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -1185,9 +1185,7 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// let mut a = Matrix::new(3, 2, (0..6).collect::<Vec<usize>>());
     ///
     /// for mut row in a.iter_rows_mut() {
-    ///     for r in row.raw_slice_mut() {
-    ///         *r = *r + 1;
-    ///     }
+    ///     *row += 1;
     /// }
     ///
     /// // Now contains the range 1..7

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -101,15 +101,15 @@ pub trait BaseMatrix<T>: Sized {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
     /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let col = mat.get_col(1).unwrap();
+    /// let col = mat.col(1).unwrap();
     /// let expected = matrix![1usize; 4; 7];
     /// assert_matrix_eq!(col, expected);
-    /// assert!(mat.get_col(5).is_none());
+    /// assert!(mat.col(5).is_none());
     /// # }
     /// ```
-    fn get_col(&self, index: usize) -> Option<MatrixSlice<T>> {
+    fn col(&self, index: usize) -> Option<MatrixSlice<T>> {
         if index < self.cols() {
-            unsafe { Some(self.get_col_unchecked(index)) }
+            unsafe { Some(self.col_unchecked(index)) }
         } else {
             None
         }
@@ -128,12 +128,12 @@ pub trait BaseMatrix<T>: Sized {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
     /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let col = unsafe { mat.get_col_unchecked(2) };
+    /// let col = unsafe { mat.col_unchecked(2) };
     /// let expected = matrix![2usize; 5; 8];
     /// assert_matrix_eq!(col, expected);
     /// # }
     /// ```
-    unsafe fn get_col_unchecked(&self, index: usize) -> MatrixSlice<T> {
+    unsafe fn col_unchecked(&self, index: usize) -> MatrixSlice<T> {
         let ptr = self.as_ptr().offset(index as isize);
         MatrixSlice::from_raw_parts(ptr,
                                     self.rows(),
@@ -154,15 +154,15 @@ pub trait BaseMatrix<T>: Sized {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
     /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let row = mat.get_row(1).unwrap();
+    /// let row = mat.row(1).unwrap();
     /// let expected = matrix![3usize, 4, 5];
     /// assert_matrix_eq!(row, expected);
-    /// assert!(mat.get_row(5).is_none());
+    /// assert!(mat.row(5).is_none());
     /// # }
     /// ```
-    fn get_row(&self, index: usize) -> Option<MatrixSlice<T>> {
+    fn row(&self, index: usize) -> Option<MatrixSlice<T>> {
         if index < self.rows() {
-            unsafe { Some(self.get_row_unchecked(index)) }
+            unsafe { Some(self.row_unchecked(index)) }
         } else {
             None
         }
@@ -180,12 +180,12 @@ pub trait BaseMatrix<T>: Sized {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
     /// let mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-    /// let row = unsafe { mat.get_row_unchecked(2) };
+    /// let row = unsafe { mat.row_unchecked(2) };
     /// let expected = matrix![6usize, 7, 8];
     /// assert_matrix_eq!(row, expected);
     /// # }
     /// ```
-    unsafe fn get_row_unchecked(&self, index: usize) -> MatrixSlice<T> {
+    unsafe fn row_unchecked(&self, index: usize) -> MatrixSlice<T> {
         let ptr = self.as_ptr().offset((self.row_stride() * index) as isize);
         MatrixSlice::from_raw_parts(ptr,
                                     1,
@@ -412,7 +412,7 @@ pub trait BaseMatrix<T>: Sized {
 
         for row in row_iter.clone() {
             unsafe {
-                let slice = self.get_row_unchecked(*row);
+                let slice = self.row_unchecked(*row);
                 mat_vec.extend_from_slice(slice.as_contiguous_slice().unwrap());
             }
         }
@@ -992,16 +992,16 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
     /// {
-    ///     let col = slice.get_col_mut(1).unwrap();
+    ///     let col = slice.col_mut(1).unwrap();
     ///     let mut expected = matrix![5usize; 8];
     ///     assert_matrix_eq!(col, expected);
     /// }
-    /// assert!(slice.get_col_mut(5).is_none());
+    /// assert!(slice.col_mut(5).is_none());
     /// # }
     /// ```
-    fn get_col_mut(&mut self, index: usize) -> Option<MatrixSliceMut<T>> {
+    fn col_mut(&mut self, index: usize) -> Option<MatrixSliceMut<T>> {
         if index < self.cols() {
-            unsafe { Some(self.get_col_unchecked_mut(index)) }
+            unsafe { Some(self.col_unchecked_mut(index)) }
         } else {
             None
         }
@@ -1021,12 +1021,12 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     ///
     /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
-    /// let col = unsafe { slice.get_col_unchecked_mut(1) };
+    /// let col = unsafe { slice.col_unchecked_mut(1) };
     /// let mut expected = matrix![5usize; 8];
     /// assert_matrix_eq!(col, expected);
     /// # }
     /// ```
-    unsafe fn get_col_unchecked_mut(&mut self, index: usize) -> MatrixSliceMut<T> {
+    unsafe fn col_unchecked_mut(&mut self, index: usize) -> MatrixSliceMut<T> {
         let ptr = self.as_mut_ptr().offset(index as isize);
         MatrixSliceMut::from_raw_parts(ptr,
                                         self.rows(),
@@ -1049,16 +1049,16 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
     /// {
-    ///     let row = slice.get_row_mut(1).unwrap();
+    ///     let row = slice.row_mut(1).unwrap();
     ///     let mut expected = matrix![7usize, 8];
     ///     assert_matrix_eq!(row, expected);
     /// }
-    /// assert!(slice.get_row_mut(5).is_none());
+    /// assert!(slice.row_mut(5).is_none());
     /// # }
     /// ```
-    fn get_row_mut(&mut self, index: usize) -> Option<MatrixSliceMut<T>> {
+    fn row_mut(&mut self, index: usize) -> Option<MatrixSliceMut<T>> {
         if index < self.rows() {
-            unsafe { Some(self.get_row_unchecked_mut(index)) }
+            unsafe { Some(self.row_unchecked_mut(index)) }
         } else {
             None
         }
@@ -1078,12 +1078,12 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     ///
     /// let mut mat = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
     /// let mut slice = mat.sub_slice_mut([1,1], 2, 2);
-    /// let row = unsafe { slice.get_row_unchecked_mut(1) };
+    /// let row = unsafe { slice.row_unchecked_mut(1) };
     /// let mut expected = matrix![7usize, 8];
     /// assert_matrix_eq!(row, expected);
     /// # }
     /// ```
-    unsafe fn get_row_unchecked_mut(&mut self, index: usize) -> MatrixSliceMut<T> {
+    unsafe fn row_unchecked_mut(&mut self, index: usize) -> MatrixSliceMut<T> {
         let ptr = self.as_mut_ptr().offset((self.row_stride() * index) as isize);
         MatrixSliceMut::from_raw_parts(ptr,
                                             1,


### PR DESCRIPTION
This is a very incomplete PR. I'm just putting in the request so I can track outstanding work more easily. Still to do:

- [x] Add column equivalents
- [x] Update row iterator
- [x] Rename functions to remove `get_` prefix. (Does this make the unchecked functions look weird?)
- [x] Explore custom types for `Row` and `Col`.
- [x] Benchmarks to compare performance
- [x] Basic evaluation of vectorization issues. (Do we need to keep casting to contiguous slices?)
- [x] Indexing for Row and Column types

There is some discussion in issue #87 . There are other ideas here which I would like to explore if I have time.

With this PR I'll try to work towards an agreeable API for these changes.

Also resolved #85 with this PR.