### PR TITLE
New metric traits

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,6 +1,7 @@
 #![feature(test)]
 
 extern crate rulinalg;
+extern crate num as libnum;
 extern crate test;
 extern crate rand;
 
@@ -8,4 +9,5 @@ mod linalg {
 	mod iter;
 	mod matrix;
 	mod svd;
+	mod norm;
 }

--- a/benches/linalg/norm.rs
+++ b/benches/linalg/norm.rs
@@ -25,6 +25,30 @@ fn lp_1_mat_100_50(b: &mut Bencher) {
 }
 
 #[bench]
+fn sum_abs_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+
+    b.iter(|| {
+        let mut s = 0.0;
+        for x in a.iter() {
+            black_box(s = s + x.abs());
+        }
+    });
+}
+
+#[bench]
+fn sum_abs_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+
+    b.iter(|| {
+        let mut s = 0.0;
+        for x in a.iter() {
+            black_box(s = s + x.abs());
+        }
+    });
+}
+
+#[bench]
 fn lp_2_mat_10_50(b: &mut Bencher) {
     let a = Matrix::new(10, 50, vec![2.0;500]);
     let lp = Lp::Integer(2);
@@ -119,29 +143,5 @@ fn euclidean_mat_100_50(b: &mut Bencher) {
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&Euclidean, &a));
-    });
-}
-
-#[bench]
-fn sum_abs_mat_10_50(b: &mut Bencher) {
-    let a = Matrix::new(10, 50, vec![2.0;500]);
-    
-    b.iter(|| {
-        let mut s = 0.0;
-        for x in a.iter() {
-            black_box(s = s + x.abs());
-        }
-    });
-}
-
-#[bench]
-fn sum_abs_mat_100_50(b: &mut Bencher) {
-    let a = Matrix::new(100, 50, vec![2.0;5000]);
-    
-    b.iter(|| {
-        let mut s = 0.0;
-        for x in a.iter() {
-            black_box(s = s + x.abs());
-        }
     });
 }

--- a/benches/linalg/norm.rs
+++ b/benches/linalg/norm.rs
@@ -1,0 +1,87 @@
+use rulinalg::matrix::{Matrix, BaseMatrix};
+use rulinalg::norm::*;
+use libnum::Float;
+use test::Bencher;
+use test::black_box;
+
+#[bench]
+fn lp_1_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    let lp = Lp(1.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_1_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    let lp = Lp(1.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_2_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    let lp = Lp(2.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_2_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    let lp = Lp(2.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn euclidean_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&Euclidean, &a));
+    });
+}
+
+#[bench]
+fn euclidean_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&Euclidean, &a));
+    });
+}
+
+#[bench]
+fn sum_abs_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    
+    b.iter(|| {
+        let mut s = 0.0;
+        for x in a.iter() {
+            black_box(s = s + x.abs());
+        }
+    });
+}
+
+#[bench]
+fn sum_abs_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    
+    b.iter(|| {
+        let mut s = 0.0;
+        for x in a.iter() {
+            black_box(s = s + x.abs());
+        }
+    });
+}

--- a/benches/linalg/norm.rs
+++ b/benches/linalg/norm.rs
@@ -45,6 +45,26 @@ fn lp_2_mat_100_50(b: &mut Bencher) {
 }
 
 #[bench]
+fn lp_3_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    let lp = Lp(3.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_3_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    let lp = Lp(3.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
 fn euclidean_mat_10_50(b: &mut Bencher) {
     let a = Matrix::new(10, 50, vec![2.0;500]);
 
@@ -82,6 +102,30 @@ fn sum_abs_mat_100_50(b: &mut Bencher) {
         let mut s = 0.0;
         for x in a.iter() {
             black_box(s = s + x.abs());
+        }
+    });
+}
+
+#[bench]
+fn sum_abs_powi_3_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    
+    b.iter(|| {
+        let mut s = 0.0;
+        for x in a.iter() {
+            black_box(s = s + x.abs().powi(3));
+        }
+    });
+}
+
+#[bench]
+fn sum_abs_powi_3_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    
+    b.iter(|| {
+        let mut s = 0.0;
+        for x in a.iter() {
+            black_box(s = s + x.abs().powi(3));
         }
     });
 }

--- a/benches/linalg/norm.rs
+++ b/benches/linalg/norm.rs
@@ -7,7 +7,7 @@ use test::black_box;
 #[bench]
 fn lp_1_mat_10_50(b: &mut Bencher) {
     let a = Matrix::new(10, 50, vec![2.0;500]);
-    let lp = Lp(1.0);
+    let lp = Lp::Integer(1);
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&lp, &a));
@@ -17,7 +17,7 @@ fn lp_1_mat_10_50(b: &mut Bencher) {
 #[bench]
 fn lp_1_mat_100_50(b: &mut Bencher) {
     let a = Matrix::new(100, 50, vec![2.0;5000]);
-    let lp = Lp(1.0);
+    let lp = Lp::Integer(1);
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&lp, &a));
@@ -27,7 +27,7 @@ fn lp_1_mat_100_50(b: &mut Bencher) {
 #[bench]
 fn lp_2_mat_10_50(b: &mut Bencher) {
     let a = Matrix::new(10, 50, vec![2.0;500]);
-    let lp = Lp(2.0);
+    let lp = Lp::Integer(2);
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&lp, &a));
@@ -37,7 +37,7 @@ fn lp_2_mat_10_50(b: &mut Bencher) {
 #[bench]
 fn lp_2_mat_100_50(b: &mut Bencher) {
     let a = Matrix::new(100, 50, vec![2.0;5000]);
-    let lp = Lp(2.0);
+    let lp = Lp::Integer(2);
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&lp, &a));
@@ -47,7 +47,7 @@ fn lp_2_mat_100_50(b: &mut Bencher) {
 #[bench]
 fn lp_3_mat_10_50(b: &mut Bencher) {
     let a = Matrix::new(10, 50, vec![2.0;500]);
-    let lp = Lp(3.0);
+    let lp = Lp::Integer(3);
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&lp, &a));
@@ -57,7 +57,47 @@ fn lp_3_mat_10_50(b: &mut Bencher) {
 #[bench]
 fn lp_3_mat_100_50(b: &mut Bencher) {
     let a = Matrix::new(100, 50, vec![2.0;5000]);
-    let lp = Lp(3.0);
+    let lp = Lp::Integer(3);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_float_2_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    let lp = Lp::Float(2.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_float_2_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    let lp = Lp::Float(2.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_float_3_mat_10_50(b: &mut Bencher) {
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    let lp = Lp::Float(3.0);
+
+    b.iter(|| {
+    	let _ = black_box(MatrixNorm::norm(&lp, &a));
+    });
+}
+
+#[bench]
+fn lp_float_3_mat_100_50(b: &mut Bencher) {
+    let a = Matrix::new(100, 50, vec![2.0;5000]);
+    let lp = Lp::Float(3.0);
 
     b.iter(|| {
     	let _ = black_box(MatrixNorm::norm(&lp, &a));
@@ -102,30 +142,6 @@ fn sum_abs_mat_100_50(b: &mut Bencher) {
         let mut s = 0.0;
         for x in a.iter() {
             black_box(s = s + x.abs());
-        }
-    });
-}
-
-#[bench]
-fn sum_abs_powi_3_mat_10_50(b: &mut Bencher) {
-    let a = Matrix::new(10, 50, vec![2.0;500]);
-    
-    b.iter(|| {
-        let mut s = 0.0;
-        for x in a.iter() {
-            black_box(s = s + x.abs().powi(3));
-        }
-    });
-}
-
-#[bench]
-fn sum_abs_powi_3_mat_100_50(b: &mut Bencher) {
-    let a = Matrix::new(100, 50, vec![2.0;5000]);
-    
-    b.iter(|| {
-        let mut s = 0.0;
-        for x in a.iter() {
-            black_box(s = s + x.abs().powi(3));
         }
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,15 +98,11 @@ pub mod error;
 pub mod utils;
 pub mod vector;
 pub mod ulp;
+pub mod norm;
 
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
 
-/// Trait for linear algebra metrics.
-///
-/// Currently only implements basic euclidean norm.
-pub trait Metric<T> {
-    /// Computes the euclidean norm.
-    fn norm(&self) -> T;
-}
+pub use norm::{VectorNorm, MatrixNorm};
+pub use norm::{VectorMetric, MatrixMetric};

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -1,4 +1,5 @@
 use matrix::{Matrix, MatrixSliceMut, BaseMatrix, BaseMatrixMut};
+use norm::Euclidean;
 use error::{Error, ErrorKind};
 
 use std::cmp;
@@ -22,8 +23,8 @@ impl<T: Any + Float + Signed> Matrix<T> {
             converged = true;
 
             for i in 0..n {
-                let mut c = self.select_cols(&[i]).norm();
-                let mut r = self.select_rows(&[i]).norm();
+                let mut c = self.select_cols(&[i]).norm(Euclidean);
+                let mut r = self.select_rows(&[i]).norm(Euclidean);
 
                 let s = c * c + r * r;
                 let mut f = T::one();

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -1,6 +1,5 @@
 use matrix::{Matrix, MatrixSliceMut, BaseMatrix, BaseMatrixMut};
 use error::{Error, ErrorKind};
-use Metric;
 
 use std::cmp;
 use std::any::Any;

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -21,6 +21,7 @@ mod eigen;
 use std::any::Any;
 
 use matrix::{Matrix, BaseMatrix};
+use norm::Euclidean;
 use vector::Vector;
 use utils;
 use error::{Error, ErrorKind};
@@ -87,6 +88,6 @@ impl<T> Matrix<T>
         v[0] = T::one();
         let v = Matrix::new(size, 1, v);
 
-        Ok(&v / v.norm())
+        Ok(&v / v.norm(Euclidean))
     }
 }

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -20,9 +20,8 @@ mod eigen;
 
 use std::any::Any;
 
-use matrix::{Matrix};
+use matrix::{Matrix, BaseMatrix};
 use vector::Vector;
-use Metric;
 use utils;
 use error::{Error, ErrorKind};
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -12,7 +12,6 @@ use std::fmt;
 use std::marker::PhantomData;
 use libnum::{One, Zero, Float, FromPrimitive};
 
-use Metric;
 use error::{Error, ErrorKind};
 use utils;
 use vector::Vector;
@@ -731,79 +730,6 @@ impl<T: Any + Float> Matrix<T> {
 
             sgn * d
         }
-    }
-}
-
-impl<T: Float> Metric<T> for Matrix<T> {
-    /// Compute euclidean norm for matrix.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rulinalg::matrix::Matrix;
-    /// use rulinalg::Metric;
-    ///
-    /// let a = Matrix::new(2,1, vec![3.0,4.0]);
-    /// let c = a.norm();
-    ///
-    /// assert_eq!(c, 5.0);
-    /// ```
-    fn norm(&self) -> T {
-        let s = utils::dot(&self.data, &self.data);
-
-        s.sqrt()
-    }
-}
-
-impl<'a, T: Float> Metric<T> for MatrixSlice<'a, T> {
-    /// Compute euclidean norm for matrix.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rulinalg::matrix::{Matrix, MatrixSlice};
-    /// use rulinalg::Metric;
-    ///
-    /// let a = Matrix::new(2,1, vec![3.0,4.0]);
-    /// let b = MatrixSlice::from_matrix(&a, [0,0], 2, 1);
-    /// let c = b.norm();
-    ///
-    /// assert_eq!(c, 5.0);
-    /// ```
-    fn norm(&self) -> T {
-        let mut s = T::zero();
-
-        for row in self.iter_rows() {
-            let raw_slice = row.raw_slice();
-            s = s + utils::dot(raw_slice, raw_slice);
-        }
-        s.sqrt()
-    }
-}
-
-impl<'a, T: Float> Metric<T> for MatrixSliceMut<'a, T> {
-    /// Compute euclidean norm for matrix.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rulinalg::matrix::{Matrix, MatrixSliceMut};
-    /// use rulinalg::Metric;
-    ///
-    /// let mut a = Matrix::new(2,1, vec![3.0,4.0]);
-    /// let b = MatrixSliceMut::from_matrix(&mut a, [0,0], 2, 1);
-    /// let c = b.norm();
-    ///
-    /// assert_eq!(c, 5.0);
-    /// ```
-    fn norm(&self) -> T {
-        let mut s = T::zero();
-
-        for row in self.iter_rows() {
-            let raw_slice = row.raw_slice();
-            s = s + utils::dot(raw_slice, raw_slice);
-        }
-        s.sqrt()
     }
 }
 

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -24,7 +24,7 @@ use matrix::{Row, RowMut, Column, ColumnMut, Rows, RowsMut, Axes};
 use matrix::{DiagOffset, Diagonal, DiagonalMut};
 use matrix::{back_substitution, forward_substitution};
 use vector::Vector;
-use norm::{MatrixNorm, Euclidean};
+use norm::{MatrixNorm, MatrixMetric};
 use utils;
 use libnum::{Zero, Float};
 use error::Error;
@@ -333,12 +333,15 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = a.sum_cols();
     /// assert_eq!(*c.data(), vec![3.0, 7.0]);
+    /// # }
     /// ```
     fn sum_cols(&self) -> Vector<T>
         where T: Copy + Zero + Add<T, Output = T>
@@ -348,22 +351,52 @@ pub trait BaseMatrix<T>: Sized {
         Vector::new(col_sum)
     }
 
-    /// Compute euclidean norm for matrix.
+    /// Compute given matrix norm for matrix.
     ///
     /// # Examples
     ///
     /// ```
-    /// use rulinalg::matrix::{Matrix, BaseMatrix};
+    /// # #[macro_use] extern crate rulinalg; fn main() {
+    /// use rulinalg::matrix::BaseMatrix;
+    /// use rulinalg::norm::Euclidean;
     ///
-    /// let a = Matrix::new(2,1, vec![3.0,4.0]);
-    /// let c = a.norm();
+    /// let a = matrix![3.0, 4.0];
+    /// let c = a.norm(Euclidean);
     ///
     /// assert_eq!(c, 5.0);
+    /// # }
     /// ```
-    fn norm(&self) -> T
+    fn norm<N: MatrixNorm<T, Self>>(&self, norm: N) -> T
         where T: Float
     {
-        Euclidean.norm(self)
+        norm.norm(self)
+    }
+
+    /// Compute the metric distance between two matrices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
+    /// use rulinalg::matrix::BaseMatrix;
+    /// use rulinalg::norm::Euclidean;
+    ///
+    /// let a = matrix![3.0, 4.0;
+    ///                 1.0, 2.0];
+    /// let b = matrix![2.0, 5.0;
+    ///                 0.0, 3.0];
+    ///
+    /// // Compute the square root of the sum of
+    /// // elementwise squared-differences
+    /// let c = a.metric(&b, Euclidean);
+    ///
+    /// assert_eq!(c, 2.0);
+    /// # }
+    /// ```
+    fn metric<'a, 'b, B, M>(&'a self, mat: &'b B, metric: M) -> T 
+        where B: 'b + BaseMatrix<T>, M: MatrixMetric<'a, 'b, T, Self, B>
+    {
+        metric.metric(self, mat)
     }
 
     /// The sum of all elements in the matrix
@@ -371,12 +404,15 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
-    /// use rulinalg::matrix::{Matrix, BaseMatrix};
+    /// # #[macro_use] extern crate rulinalg; fn main() {
+    /// use rulinalg::matrix::BaseMatrix;
     ///
-    /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = a.sum();
     /// assert_eq!(c, 10.0);
+    /// # }
     /// ```
     fn sum(&self) -> T
         where T: Copy + Zero + Add<T, Output = T>

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -1,4 +1,4 @@
-//! Traits for matrices operations.
+//! Traits for matrix operations.
 //!
 //! These traits defines operations for structs representing matrices arranged in row-major order.
 //!

--- a/src/matrix/slice.rs
+++ b/src/matrix/slice.rs
@@ -24,6 +24,7 @@ use matrix::{Row, RowMut, Column, ColumnMut, Rows, RowsMut, Axes};
 use matrix::{DiagOffset, Diagonal, DiagonalMut};
 use matrix::{back_substitution, forward_substitution};
 use vector::Vector;
+use norm::{MatrixNorm, Euclidean};
 use utils;
 use libnum::{Zero, Float};
 use error::Error;
@@ -345,6 +346,24 @@ pub trait BaseMatrix<T>: Sized {
         let mut col_sum = Vec::with_capacity(self.rows());
         col_sum.extend(self.iter_rows().map(|row| utils::unrolled_sum(row.raw_slice())));
         Vector::new(col_sum)
+    }
+
+    /// Compute euclidean norm for matrix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::matrix::{Matrix, BaseMatrix};
+    ///
+    /// let a = Matrix::new(2,1, vec![3.0,4.0]);
+    /// let c = a.norm();
+    ///
+    /// assert_eq!(c, 5.0);
+    /// ```
+    fn norm(&self) -> T
+        where T: Float
+    {
+        Euclidean.norm(self)
     }
 
     /// The sum of all elements in the matrix

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -1,4 +1,27 @@
 //! The norm module
+//!
+//! This module contains implementations of various linear algebra norms.
+//! The implementations are contained within the `VectorNorm` and 
+//! `MatrixNorm` traits. This module also contains `VectorMetric` and
+//! `MatrixMetric` traits which are used to compute the metric distance.
+//!
+//! These traits can be used directly by importing implementors from
+//! this module. In most cases it will be easier to use the `norm` and
+//! `metric` functions which exist for both vectors and matrices. These
+//! functions take generic arguments for the norm to be used.
+//!
+//! In general you should use the least generic norm that fits your purpose.
+//! For example you would choose to use a `Euclidean` norm instead of an
+//! `Lp(2.0)` norm - despite them being mathematically equivalent. 
+//!
+//! # Defining your own norm
+//!
+//! Note that these traits enforce no requirements on the norm. It is up
+//! to the user to ensure that they define a norm correctly.
+//!
+//! To define your own norm you need to implement the `MatrixNorm`
+//! and/or the `VectorNorm` on your own struct. When you have defined
+//! a norm you get the _induced metric_ for free.
 
 use matrix::BaseMatrix;
 use vector::Vector;
@@ -34,7 +57,8 @@ pub trait MatrixMetric<'a, 'b, T, M1: 'a + BaseMatrix<T>, M2: 'b + BaseMatrix<T>
 /// The induced vector metric
 ///
 /// Given a norm `N`, the induced vector metric `M` computes
-/// the metric distance `d` as follows:
+/// the metric distance, `d`, between two vectors `v1` and `v2`
+/// as follows:
 ///
 /// `d = M(v1, v2) = N(v1 - v2)`
 impl<U, T> VectorMetric<T> for U
@@ -44,6 +68,13 @@ impl<U, T> VectorMetric<T> for U
     }
 }
 
+/// The induced matrix metric
+///
+/// Given a norm `N`, the induced matrix metric `M` computes
+/// the metric distance, `d`, between two matrices `m1` and `m2`
+/// as follows:
+///
+/// `d = M(m1, m2) = N(m1 - m2)`
 impl<'a, 'b, U, T, M1, M2> MatrixMetric<'a, 'b, T, M1, M2> for U
     where U: MatrixNorm<T, M1>,
     M1: 'a + BaseMatrix<T>,
@@ -56,6 +87,11 @@ impl<'a, 'b, U, T, M1, M2> MatrixMetric<'a, 'b, T, M1, M2> for U
 }
 
 /// The Euclidean norm
+///
+/// The Euclidean norm computes the square-root
+/// of the sum of squares.
+///
+/// `||v|| = SQRT(SUM(v_i * v_i))`
 #[derive(Debug)]
 pub struct Euclidean;
 
@@ -78,6 +114,17 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
 }
 
 /// The Lp norm
+///
+/// The Lp norm computes the `p`th root
+/// of the sum of elements to the `p`th power.
+///
+/// The Lp norm requires `p` to be greater than
+/// or equal `1`.
+///
+/// # p = infinity
+///
+/// In the special case where `p` is positive infinity,
+/// the Lp norm becomes a supremum over the absolute values.
 #[derive(Debug)]
 pub struct Lp<T: Float>(T);
 

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -180,21 +180,56 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
 mod tests {
     use super::*;
     use vector::Vector;
-    use matrix::MatrixSlice;
+    use matrix::{Matrix, MatrixSlice};
 
     #[test]
-    fn test_euclidean_vector() {
+    fn test_euclidean_vector_norm() {
         let v = Vector::new(vec![3.0, 4.0]);
         assert!((VectorNorm::norm(&Euclidean, &v) - 5.0) < 1e-30);
     }
 
     #[test]
-    fn test_euclidean_matrix() {
+    fn test_euclidean_matrix_norm() {
         let m = matrix![3.0, 4.0;
                         1.0, 3.0];
         assert!((MatrixNorm::norm(&Euclidean, &m) - 35.0.sqrt()) < 1e-30);
 
         let slice = MatrixSlice::from_matrix(&m, [0,0], 1, 2);
         assert!((MatrixNorm::norm(&Euclidean, &slice) - 5.0) < 1e-30);
+    }
+
+    #[test]
+    fn test_euclidean_vector_metric() {
+        let v = Vector::new(vec![3.0, 4.0]);
+        assert!((VectorMetric::metric(&Euclidean, &v, &v)) < 1e-30);
+
+        let v1 = Vector::new(vec![0.0, 0.0]);
+        assert!((VectorMetric::metric(&Euclidean, &v, &v1) - 5.0) < 1e-30);
+
+        let v2 = Vector::new(vec![4.0, 3.0]);
+        assert!((VectorMetric::metric(&Euclidean, &v, &v2) - 2.0.sqrt()) < 1e-30);
+    }
+
+    #[test]
+    fn test_euclidean_matrix_metric() {
+        let m = matrix![3.0, 4.0;
+                        1.0, 3.0];
+        assert!((MatrixMetric::metric(&Euclidean, &m, &m)) < 1e-30);
+
+        let m1 = Matrix::zeros(2, 2);
+        assert!((MatrixMetric::metric(&Euclidean, &m, &m1) - 35.0.sqrt()) < 1e-30);
+
+        let m2 = matrix![2.0, 3.0;
+                         2.0, 4.0];
+        assert!((MatrixMetric::metric(&Euclidean, &m, &m2) - 2.0) < 1e-30);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_euclidean_matrix_metric_bad_dim() {
+        let m = matrix![3.0, 4.0];
+        let m2 = matrix![1.0, 2.0, 3.0];
+
+        MatrixMetric::metric(&Euclidean, &m, &m2);
     }
 }

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -127,12 +127,14 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
 /// The Lp norm requires `p` to be greater than
 /// or equal `1`.
 ///
-/// # p = infinity
+/// We use an enum for this norm to allow us to explicitly handle
+/// special cases at compile time. For example, we have an `Infinity`
+/// variant which handles the special case when the `Lp` norm is a
+/// supremum over absolute values. The `Integer` variant gives us a
+/// performance boost when `p` is an integer.
 ///
-/// In the special case where `p` is positive infinity,
-/// the Lp norm becomes a supremum over the absolute values.
-///
-/// TODO: Explain enum a little more
+/// You should avoid matching directly against this enum as it is likely
+/// to grow.
 #[derive(Debug)]
 pub enum Lp<T: Float> {
     /// The L-infinity norm (supremum)
@@ -163,6 +165,7 @@ impl<T: Float> VectorNorm<T> for Lp<T> {
                 for x in v {
                     s = s + x.abs().powi(i);
                 }
+                s
                 s.powf(T::from(i).expect("Could not cast i32 to float").recip())
             },
             Lp::Float(p) => {

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -158,14 +158,14 @@ impl<T: Float> VectorNorm<T> for Lp<T> {
                 }
                 abs_sup
             },
-            Lp::Integer(i) => {
-                assert!(i >= 1, "p value in Lp norm must be >= 1");
+            Lp::Integer(p) => {
+                assert!(p >= 1, "p value in Lp norm must be >= 1");
                 // Compute standard lp norm
                 let mut s = T::zero();
                 for x in v {
-                    s = s + x.abs().powi(i);
+                    s = s + x.abs().powi(p);
                 }
-                s.powf(T::from(i).expect("Could not cast i32 to float").recip())
+                s.powf(T::from(p).expect("Could not cast i32 to float").recip())
             },
             Lp::Float(p) => {
                 assert!(p >= T::one(), "p value in Lp norm must be >= 1");
@@ -197,8 +197,8 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
                 assert!(p >= 1, "p value in Lp norm must be >= 1");
                 // Compute standard lp norm
                 let mut s = T::zero();
-                for x in m.iter().map(|d| d.abs()) {
-                    s = s + x.powi(p);
+                for x in m.iter() {
+                    s = s + x.abs().powi(p);
                 }
                 s.powf(T::from(p).expect("Could not cast i32 to float").recip())
             },
@@ -206,8 +206,8 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
                 assert!(p >= T::one(), "p value in Lp norm must be >= 1");
                 // Compute standard lp norm
                 let mut s = T::zero();
-                for x in m.iter().map(|d| d.abs()) {
-                    s = s + x.powf(p);
+                for x in m.iter() {
+                    s = s + x.abs().powf(p);
                 }
                 s.powf(p.recip())
             }

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -211,6 +211,15 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn test_euclidean_vector_metric_bad_dim() {
+        let v = Vector::new(vec![3.0, 4.0]);
+        let v2 = Vector::new(vec![1.0, 2.0, 3.0]);
+
+        VectorMetric::metric(&Euclidean, &v, &v2);
+    }
+
+    #[test]
     fn test_euclidean_matrix_metric() {
         let m = matrix![3.0, 4.0;
                         1.0, 3.0];

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -135,9 +135,9 @@ impl<T: Float> VectorNorm<T> for Lp<T> {
         } else if self.0.is_infinite() {
             // Compute supremum
             let mut abs_sup = T::zero();
-            for d in v {
-                if d.abs() > abs_sup {
-                    abs_sup = *d;
+            for d in v.iter().map(|d| d.abs()) {
+                if d > abs_sup {
+                    abs_sup = d;
                 }
             }
             abs_sup
@@ -159,9 +159,9 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
         } else if self.0.is_infinite() {
             // Compute supremum
             let mut abs_sup = T::zero();
-            for d in m.iter() {
-                if d.abs() > abs_sup {
-                    abs_sup = *d;
+            for d in m.iter().map(|d| d.abs()) {
+                if d > abs_sup {
+                    abs_sup = d;
                 }
             }
             abs_sup
@@ -179,6 +179,8 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
 #[cfg(test)]
 mod tests {
     use libnum::Float;
+    use std::f64;
+
     use super::*;
     use vector::Vector;
     use matrix::{Matrix, MatrixSlice};
@@ -241,5 +243,49 @@ mod tests {
         let m2 = matrix![1.0, 2.0, 3.0];
 
         MatrixMetric::metric(&Euclidean, &m, &m2);
+    }
+
+    #[test]
+    fn test_lp_vector_supremum() {
+        let v = Vector::new(vec![-5.0, 3.0]);
+
+        let sup = VectorNorm::norm(&Lp(f64::INFINITY), &v);
+        assert_eq!(sup, 5.0);
+    }
+
+    #[test]
+    fn test_lp_matrix_supremum() {
+        let m = matrix![0.0, -2.0;
+                        3.5, 1.0];
+
+        let sup = MatrixNorm::norm(&Lp(f64::INFINITY), &m);
+        assert_eq!(sup, 3.5);
+    }
+
+    #[test]
+    fn test_lp_vector_one() {
+        let v = Vector::new(vec![1.0, 2.0, -2.0]);
+        assert_eq!(VectorNorm::norm(&Lp(1.0), &v), 5.0);
+    }
+
+    #[test]
+    fn test_lp_matrix_one() {
+        let m = matrix![1.0, -2.0;
+                        0.5, 1.0];
+        assert_eq!(MatrixNorm::norm(&Lp(1.0), &m), 4.5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lp_vector_bad_p() {
+        let v = Vector::new(vec![]);
+        VectorNorm::norm(&Lp(0.5), &v);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lp_matrix_bad_p() {
+        let m = matrix![];
+        MatrixNorm::norm(&Lp(0.5), &m);
     }
 }

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -178,6 +178,7 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
 
 #[cfg(test)]
 mod tests {
+    use libnum::Float;
     use super::*;
     use vector::Vector;
     use matrix::{Matrix, MatrixSlice};

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -55,7 +55,7 @@ impl<'a, 'b, U, T, M1, M2> MatrixMetric<'a, 'b, T, M1, M2> for U
     }
 }
 
-/// The Euclidean norm and metric.
+/// The Euclidean norm
 #[derive(Debug)]
 pub struct Euclidean;
 
@@ -74,5 +74,57 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
         }
 
         s.sqrt()
+    }
+}
+
+/// The Lp norm
+#[derive(Debug)]
+pub struct Lp<T: Float>(T);
+
+impl<T: Float> VectorNorm<T> for Lp<T> {
+    fn norm(&self, v: &Vector<T>) -> T {
+        if self.0 < T::one() {
+            panic!("p value in Lp norm must >= 1")
+        } else if self.0.is_infinite() {
+            // Compute supremum
+            let mut abs_sup = T::zero();
+            for d in v {
+                if d.abs() > abs_sup {
+                    abs_sup = *d;
+                }
+            }
+            abs_sup
+        } else {
+            // Compute standard lp norm
+            let mut s = T::zero();
+            for x in v {
+                s = s + x.abs().powf(self.0);
+            }
+            s.powf(self.0.recip())
+        }
+    }
+}
+
+impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
+    fn norm(&self, m: &M) -> T {
+        if self.0 < T::one() {
+            panic!("p value in Lp norm must >= 1")
+        } else if self.0.is_infinite() {
+            // Compute supremum
+            let mut abs_sup = T::zero();
+            for d in m.iter() {
+                if d.abs() > abs_sup {
+                    abs_sup = *d;
+                }
+            }
+            abs_sup
+        } else {
+            // Compute standard lp norm
+            let mut s = T::zero();
+            for x in m.iter() {
+                s = s + x.abs().powf(self.0);
+            }
+            s.powf(self.0.recip())
+        }
     }
 }

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -175,3 +175,26 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Lp<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vector::Vector;
+    use matrix::MatrixSlice;
+
+    #[test]
+    fn test_euclidean_vector() {
+        let v = Vector::new(vec![3.0, 4.0]);
+        assert!((VectorNorm::norm(&Euclidean, &v) - 5.0) < 1e-30);
+    }
+
+    #[test]
+    fn test_euclidean_matrix() {
+        let m = matrix![3.0, 4.0;
+                        1.0, 3.0];
+        assert!((MatrixNorm::norm(&Euclidean, &m) - 35.0.sqrt()) < 1e-30);
+
+        let slice = MatrixSlice::from_matrix(&m, [0,0], 1, 2);
+        assert!((MatrixNorm::norm(&Euclidean, &slice) - 5.0) < 1e-30);
+    }
+}

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -132,7 +132,7 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
 /// In the special case where `p` is positive infinity,
 /// the Lp norm becomes a supremum over the absolute values.
 #[derive(Debug)]
-pub struct Lp<T: Float>(T);
+pub struct Lp<T: Float>(pub T);
 
 impl<T: Float> Lp<T> {
     /// Returns the L_infinity norm.

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -165,7 +165,6 @@ impl<T: Float> VectorNorm<T> for Lp<T> {
                 for x in v {
                     s = s + x.abs().powi(i);
                 }
-                s
                 s.powf(T::from(i).expect("Could not cast i32 to float").recip())
             },
             Lp::Float(p) => {

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -1,0 +1,78 @@
+//! The norm module
+
+use matrix::BaseMatrix;
+use vector::Vector;
+use utils;
+
+use std::ops::Sub;
+use libnum::Float;
+
+/// Trait for vector norms
+pub trait VectorNorm<T> {
+    /// Computes the vector norm.
+    fn norm(&self, v: &Vector<T>) -> T;
+}
+
+/// Trait for vector metrics.
+pub trait VectorMetric<T> {
+    /// Computes the metric distance between two vectors.
+    fn metric(&self, v1: &Vector<T>, v2: &Vector<T>) -> T;
+}
+
+/// Trait for matrix norms.
+pub trait MatrixNorm<T, M: BaseMatrix<T>> {
+    /// Computes the matrix norm.
+    fn norm(&self, m: &M) -> T;
+}
+
+/// Trait for matrix metrics.
+pub trait MatrixMetric<'a, 'b, T, M1: 'a + BaseMatrix<T>, M2: 'b + BaseMatrix<T>> {
+    /// Computes the metric distance between two matrices.
+    fn metric(&self, m1: &'a M1, m2: &'b M2) -> T;
+}
+
+/// The induced vector metric
+///
+/// Given a norm `N`, the induced vector metric `M` computes
+/// the metric distance `d` as follows:
+///
+/// `d = M(v1, v2) = N(v1 - v2)`
+impl<U, T> VectorMetric<T> for U
+    where U: VectorNorm<T>, T: Copy + Sub<T, Output=T> {
+    fn metric(&self, v1: &Vector<T>, v2: &Vector<T>) -> T {
+        self.norm(&(v1 - v2))
+    }
+}
+
+impl<'a, 'b, U, T, M1, M2> MatrixMetric<'a, 'b, T, M1, M2> for U
+    where U: MatrixNorm<T, M1>,
+    M1: 'a + BaseMatrix<T>,
+    M2: 'b + BaseMatrix<T>,
+    &'a M1: Sub<&'b M2, Output=M1> {
+
+    fn metric(&self, m1: &'a M1, m2: &'b M2) -> T {
+        self.norm(&(m1 - m2))
+    }
+}
+
+/// The Euclidean norm and metric.
+#[derive(Debug)]
+pub struct Euclidean;
+
+impl<T: Float> VectorNorm<T> for Euclidean {
+    fn norm(&self, v: &Vector<T>) -> T {
+        utils::dot(v.data(), v.data()).sqrt()
+    }
+}
+
+impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
+    fn norm(&self, m: &M) -> T {
+        let mut s = T::zero();
+
+        for row in m.iter_rows() {
+            s = s + utils::dot(row.raw_slice(), row.raw_slice());
+        }
+
+        s.sqrt()
+    }
+}

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -21,7 +21,11 @@
 //!
 //! To define your own norm you need to implement the `MatrixNorm`
 //! and/or the `VectorNorm` on your own struct. When you have defined
-//! a norm you get the _induced metric_ for free.
+//! a norm you get the _induced metric_ for free. This means that any
+//! object which implements the `VectorNorm` or `MatrixNorm` will
+//! automatically implement the `VectorMetric` and `MatrixMetric` traits
+//! respectively. This induced metric will compute the norm of the
+//! difference between the vectors or matrices.
 
 use matrix::BaseMatrix;
 use vector::Vector;
@@ -115,8 +119,10 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
 
 /// The Lp norm
 ///
-/// The Lp norm computes the `p`th root
-/// of the sum of elements to the `p`th power.
+/// The
+/// [Lp norm](https://en.wikipedia.org/wiki/Norm_(mathematics)#p-norm)
+/// computes the `p`th root of the sum of elements
+/// to the `p`th power.
 ///
 /// The Lp norm requires `p` to be greater than
 /// or equal `1`.
@@ -127,6 +133,26 @@ impl<T: Float, M: BaseMatrix<T>> MatrixNorm<T, M> for Euclidean {
 /// the Lp norm becomes a supremum over the absolute values.
 #[derive(Debug)]
 pub struct Lp<T: Float>(T);
+
+impl<T: Float> Lp<T> {
+    /// Returns the L_infinity norm.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
+    /// use rulinalg::norm::{MatrixNorm, Lp};
+    ///
+    /// let l_inf = Lp::infinity();
+    /// let mat = matrix![ 1.0, 2.0;
+    ///                   -4.0, 1.5];
+    /// assert_eq!(l_inf.norm(&mat), 4.0);
+    /// # }
+    /// ```
+    pub fn infinity() -> Lp<T> {
+        Lp(T::infinity())
+    }
+}
 
 impl<T: Float> VectorNorm<T> for Lp<T> {
     fn norm(&self, v: &Vector<T>) -> T {
@@ -188,29 +214,29 @@ mod tests {
     #[test]
     fn test_euclidean_vector_norm() {
         let v = Vector::new(vec![3.0, 4.0]);
-        assert!((VectorNorm::norm(&Euclidean, &v) - 5.0) < 1e-30);
+        assert!((VectorNorm::norm(&Euclidean, &v) - 5.0) < 1e-14);
     }
 
     #[test]
     fn test_euclidean_matrix_norm() {
         let m = matrix![3.0, 4.0;
                         1.0, 3.0];
-        assert!((MatrixNorm::norm(&Euclidean, &m) - 35.0.sqrt()) < 1e-30);
+        assert!((MatrixNorm::norm(&Euclidean, &m) - 35.0.sqrt()) < 1e-14);
 
         let slice = MatrixSlice::from_matrix(&m, [0,0], 1, 2);
-        assert!((MatrixNorm::norm(&Euclidean, &slice) - 5.0) < 1e-30);
+        assert!((MatrixNorm::norm(&Euclidean, &slice) - 5.0) < 1e-14);
     }
 
     #[test]
     fn test_euclidean_vector_metric() {
         let v = Vector::new(vec![3.0, 4.0]);
-        assert!((VectorMetric::metric(&Euclidean, &v, &v)) < 1e-30);
+        assert!((VectorMetric::metric(&Euclidean, &v, &v)) < 1e-14);
 
         let v1 = Vector::new(vec![0.0, 0.0]);
-        assert!((VectorMetric::metric(&Euclidean, &v, &v1) - 5.0) < 1e-30);
+        assert!((VectorMetric::metric(&Euclidean, &v, &v1) - 5.0) < 1e-14);
 
         let v2 = Vector::new(vec![4.0, 3.0]);
-        assert!((VectorMetric::metric(&Euclidean, &v, &v2) - 2.0.sqrt()) < 1e-30);
+        assert!((VectorMetric::metric(&Euclidean, &v, &v2) - 2.0.sqrt()) < 1e-14);
     }
 
     #[test]
@@ -226,14 +252,14 @@ mod tests {
     fn test_euclidean_matrix_metric() {
         let m = matrix![3.0, 4.0;
                         1.0, 3.0];
-        assert!((MatrixMetric::metric(&Euclidean, &m, &m)) < 1e-30);
+        assert!((MatrixMetric::metric(&Euclidean, &m, &m)) < 1e-14);
 
         let m1 = Matrix::zeros(2, 2);
-        assert!((MatrixMetric::metric(&Euclidean, &m, &m1) - 35.0.sqrt()) < 1e-30);
+        assert!((MatrixMetric::metric(&Euclidean, &m, &m1) - 35.0.sqrt()) < 1e-14);
 
         let m2 = matrix![2.0, 3.0;
                          2.0, 4.0];
-        assert!((MatrixMetric::metric(&Euclidean, &m, &m2) - 2.0) < 1e-30);
+        assert!((MatrixMetric::metric(&Euclidean, &m, &m2) - 2.0) < 1e-14);
     }
 
     #[test]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -9,7 +9,8 @@ use std::cmp::PartialEq;
 use std::fmt;
 use std::slice::{Iter, IterMut};
 use std::vec::IntoIter;
-use Metric;
+
+use norm::{VectorNorm, Euclidean};
 use utils;
 
 /// The Vector struct.
@@ -333,6 +334,24 @@ impl<T: Copy + Div<T, Output = T>> Vector<T> {
     pub fn elediv(&self, v: &Vector<T>) -> Vector<T> {
         assert_eq!(self.size, v.size);
         Vector::new(utils::ele_div(&self.data, &v.data))
+    }
+}
+
+impl<T: Float> Vector<T> {
+    /// Compute euclidean norm for vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::vector::Vector;
+    ///
+    /// let a = Vector::new(vec![3.0,4.0]);
+    /// let c = a.norm();
+    ///
+    /// assert_eq!(c, 5.0);
+    /// ```
+    pub fn norm(&self) -> T {
+        Euclidean.norm(self)
     }
 }
 
@@ -699,31 +718,6 @@ impl<T> IndexMut<usize> for Vector<T> {
     }
 }
 
-impl<T: Float> Metric<T> for Vector<T> {
-    /// Compute euclidean norm for vector.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rulinalg::vector::Vector;
-    /// use rulinalg::Metric;
-    ///
-    /// let a = Vector::new(vec![3.0,4.0]);
-    /// let c = a.norm();
-    ///
-    /// assert_eq!(c, 5.0);
-    /// ```
-    fn norm(&self) -> T {
-        let mut s = T::zero();
-
-        for u in &self.data {
-            s = s + (*u) * (*u);
-        }
-
-        s.sqrt()
-    }
-}
-
 macro_rules! impl_op_assign_vec_scalar (
     ($assign_trt:ident, $trt:ident, $op:ident, $op_assign:ident, $doc:expr) => (
 
@@ -785,7 +779,6 @@ impl_op_assign_vec!(SubAssign, Sub, sub, sub_assign, "subtraction");
 #[cfg(test)]
 mod tests {
     use super::Vector;
-    use super::super::Metric;
 
     #[test]
     fn test_display() {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::slice::{Iter, IterMut};
 use std::vec::IntoIter;
 
-use norm::{VectorNorm, Euclidean};
+use norm::{VectorNorm, VectorMetric};
 use utils;
 
 /// The Vector struct.
@@ -338,20 +338,41 @@ impl<T: Copy + Div<T, Output = T>> Vector<T> {
 }
 
 impl<T: Float> Vector<T> {
-    /// Compute euclidean norm for vector.
+    /// Compute vector norm for vector.
     ///
     /// # Examples
     ///
     /// ```
     /// use rulinalg::vector::Vector;
+    /// use rulinalg::norm::Euclidean;
     ///
     /// let a = Vector::new(vec![3.0,4.0]);
-    /// let c = a.norm();
+    /// let c = a.norm(Euclidean);
     ///
     /// assert_eq!(c, 5.0);
     /// ```
-    pub fn norm(&self) -> T {
-        Euclidean.norm(self)
+    pub fn norm<N: VectorNorm<T>>(&self, norm: N) -> T {
+        norm.norm(self)
+    }
+
+    /// Compute metric distance between two vectors.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::vector::Vector;
+    /// use rulinalg::norm::Euclidean;
+    ///
+    /// let a = Vector::new(vec![3.0, 4.0]);
+    /// let b = Vector::new(vec![0.0, 8.0]);
+    ///
+    /// // Compute the square root of the sum of
+    /// // elementwise squared-differences
+    /// let c = a.metric(&b, Euclidean);
+    /// assert_eq!(c, 5.0);
+    /// ```
+    pub fn metric<M: VectorMetric<T>>(&self, v: &Vector<T>, m: M) -> T {
+        m.metric(self, v)
     }
 }
 
@@ -779,6 +800,7 @@ impl_op_assign_vec!(SubAssign, Sub, sub, sub_assign, "subtraction");
 #[cfg(test)]
 mod tests {
     use super::Vector;
+    use norm::Euclidean;
 
     #[test]
     fn test_display() {
@@ -1043,10 +1065,10 @@ mod tests {
     }
 
     #[test]
-    fn vector_norm() {
+    fn vector_euclidean_norm() {
         let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
-        let b = a.norm();
+        let b = a.norm(Euclidean);
 
         assert_eq!(b, (1. + 4. + 9. + 16. + 25. + 36. as f32).sqrt());
     }


### PR DESCRIPTION
This PR attempts to resolve #81. New features include:

- Can define multiple norms using the `MatrixNorm` and `VectorNorm` traits.
- Automatically get the [_induced metric_ (fact 3)](https://www.math.usm.edu/perry/old_classes/mat681sp14/norm_and_metric.pdf) from the norm.

Some issues to work through:

- Should we keep a default euclidean implementation? _No_
- We have some performance hit for euclidean norm on `Matrix` - can specialize the implementation if we use a default function for this. _We will ignore this for now, but make a note for later._
- We have a set of traits each for vector and matrix types.

And some of the work left to do:

- [x] Add Lp norms.
- [x] Add documentation.
- [x] Add unit tests
- [x] Add a generic `norm` function to the `BaseMatrix` and `Vector` types so the user can specify which norm to use more easily.

---

Here are some benchmarks (without any Lp optimizations):

```
running 12 tests
test linalg::norm::lp_1_mat_100_50                 ... bench:       9,036 ns/iter (+/- 993)
test linalg::norm::lp_1_mat_10_50                  ... bench:         913 ns/iter (+/- 94)
test linalg::norm::sum_abs_mat_100_50              ... bench:       9,164 ns/iter (+/- 1,990)
test linalg::norm::sum_abs_mat_10_50               ... bench:         909 ns/iter (+/- 87)
test linalg::norm::lp_2_mat_100_50                 ... bench:      10,038 ns/iter (+/- 1,204)
test linalg::norm::lp_2_mat_10_50                  ... bench:       1,056 ns/iter (+/- 226)
test linalg::norm::euclidean_mat_100_50            ... bench:       3,266 ns/iter (+/- 392)
test linalg::norm::euclidean_mat_10_50             ... bench:         303 ns/iter (+/- 26)
test linalg::norm::lp_3_mat_100_50                 ... bench:     364,378 ns/iter (+/- 25,537)
test linalg::norm::lp_3_mat_10_50                  ... bench:      35,908 ns/iter (+/- 3,867)
test linalg::norm::sum_abs_powi_3_mat_100_50       ... bench:       9,436 ns/iter (+/- 1,171)
test linalg::norm::sum_abs_powi_3_mat_10_50        ... bench:         913 ns/iter (+/- 279)
```