### PR TITLE
API: add get_unchecked to Vector

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -73,6 +73,18 @@ impl<T> Vector<T> {
         self.mut_data().iter_mut()
     }
 
+    /// Returns a pointer to the element at the given index, without doing
+    /// bounds checking. So use it very carefully!
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        self.data().get_unchecked(index)
+    }
+
+    /// Returns an unsafe mutable pointer to the element in index.
+    /// So use it very carefully!
+    pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
+        self.mut_data().get_unchecked_mut(index)
+    }
+
 }
 
 impl<T> Into<Vec<T>> for Vector<T> {
@@ -1164,5 +1176,21 @@ mod tests {
         }
 
         assert_eq!(our_vector.into_vec(), vec![2., 3., 4., 5.]);
+    }
+
+    #[test]
+    fn vector_get_unchecked() {
+        let v1 = Vector::new(vec![1, 2, 3]);
+        unsafe {
+            assert_eq!(v1.get_unchecked(1), &2);
+        }
+
+        let mut v2 = Vector::new(vec![1, 2, 3]);
+
+        unsafe {
+            let elem = v2.get_unchecked_mut(1);
+            *elem = 4;
+        }
+        assert_eq!(v2, Vector::new(vec![1, 4, 3]));
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -76,13 +76,13 @@ impl<T> Vector<T> {
     /// Returns a pointer to the element at the given index, without doing
     /// bounds checking. So use it very carefully!
     pub unsafe fn get_unchecked(&self, index: usize) -> &T {
-        self.data().get_unchecked(index)
+        self.data.get_unchecked(index)
     }
 
     /// Returns an unsafe mutable pointer to the element in index.
     /// So use it very carefully!
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
-        self.mut_data().get_unchecked_mut(index)
+        self.data.get_unchecked_mut(index)
     }
 
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -74,13 +74,13 @@ impl<T> Vector<T> {
     }
 
     /// Returns a pointer to the element at the given index, without doing
-    /// bounds checking. So use it very carefully!
+    /// bounds checking.
     pub unsafe fn get_unchecked(&self, index: usize) -> &T {
         self.data.get_unchecked(index)
     }
 
-    /// Returns an unsafe mutable pointer to the element in index.
-    /// So use it very carefully!
+    /// Returns an unsafe mutable pointer to the element at the given index,
+    /// without doing bounds checking.
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
         self.data.get_unchecked_mut(index)
     }


### PR DESCRIPTION
Don't have to write ``vector.data().get_unchecked...`` to skip index boundary check. 