### PR TITLE
Removing self clone on referenced functions

### DIFF
--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -76,13 +76,13 @@ impl<T: Any + Float + Signed> Matrix<T> {
 
     }
 
-    fn francis_shift_eigenvalues(&self) -> Result<Vec<T>, Error> {
+    fn francis_shift_eigenvalues(self) -> Result<Vec<T>, Error> {
         let n = self.rows();
         debug_assert!(n > 2,
                       "Francis shift only works on matrices greater than 2x2.");
         debug_assert!(n == self.cols, "Matrix must be square for Francis shift.");
 
-        let mut h = try!(self.clone()
+        let mut h = try!(self
             .upper_hessenberg()
             .map_err(|_| Error::new(ErrorKind::DecompFailure, "Could not compute eigenvalues.")));
         h.balance_matrix();
@@ -183,7 +183,7 @@ impl<T: Any + Float + Signed> Matrix<T> {
     /// # Failures
     ///
     /// - Eigenvalues cannot be computed.
-    pub fn eigenvalues(&self) -> Result<Vec<T>, Error> {
+    pub fn eigenvalues(self) -> Result<Vec<T>, Error> {
         let n = self.rows();
         assert!(n == self.cols,
                 "Matrix must be square for eigenvalue computation.");
@@ -196,7 +196,7 @@ impl<T: Any + Float + Signed> Matrix<T> {
     }
 
     fn direct_2_by_2_eigendecomp(&self) -> Result<(Vec<T>, Matrix<T>), Error> {
-        let eigenvalues = try!(self.eigenvalues());
+        let eigenvalues = try!(self.direct_2_by_2_eigenvalues());
         // Thanks to
         // http://www.math.harvard.edu/archive/21b_fall_04/exhibits/2dmatrices/index.html
         // for this characterization—
@@ -217,13 +217,13 @@ impl<T: Any + Float + Signed> Matrix<T> {
         }
     }
 
-    fn francis_shift_eigendecomp(&self) -> Result<(Vec<T>, Matrix<T>), Error> {
+    fn francis_shift_eigendecomp(self) -> Result<(Vec<T>, Matrix<T>), Error> {
         let n = self.rows();
         debug_assert!(n > 2,
                       "Francis shift only works on matrices greater than 2x2.");
         debug_assert!(n == self.cols, "Matrix must be square for Francis shift.");
 
-        let (u, mut h) = try!(self.clone().upper_hess_decomp().map_err(|_| {
+        let (u, mut h) = try!(self.upper_hess_decomp().map_err(|_| {
             Error::new(ErrorKind::DecompFailure,
                        "Could not compute eigen decomposition.")
         }));
@@ -346,7 +346,7 @@ impl<T: Any + Float + Signed> Matrix<T> {
     /// # Failures
     ///
     /// - The eigen decomposition can not be computed.
-    pub fn eigendecomp(&self) -> Result<(Vec<T>, Matrix<T>), Error> {
+    pub fn eigendecomp(self) -> Result<(Vec<T>, Matrix<T>), Error> {
         let n = self.rows();
         assert!(n == self.cols, "Matrix must be square for eigendecomp.");
 
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn test_2_by_2_matrix_eigendecomp() {
         let a = matrix!(20., 4.; 20., 16.);
-        let (eigenvals, eigenvecs) = a.eigendecomp().unwrap();
+        let (eigenvals, eigenvecs) = a.clone().eigendecomp().unwrap();
 
         let lambda_1 = eigenvals[0];
         let lambda_2 = eigenvals[1];
@@ -416,7 +416,7 @@ mod tests {
                         22., 29., 36.;
                         27., 36., 45.);
 
-        let eigs = a.eigenvalues().unwrap();
+        let eigs = a.clone().eigenvalues().unwrap();
 
         let eig_1 = 90.4026;
         let eig_2 = 0.5973;

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -30,11 +30,11 @@ impl<T> Matrix<T> where T: Any + Float
     /// # Failures
     ///
     /// - Matrix cannot be LUP decomposed.
-    pub fn lup_decomp(&self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
+    pub fn lup_decomp(self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
         let n = self.cols;
         assert!(self.rows == n, "Matrix must be square for LUP decomposition.");
         let mut l = Matrix::<T>::zeros(n, n);
-        let mut u = self.clone();
+        let mut u = self;
         let mut p = Matrix::<T>::identity(n);
 
         for index in 0..n {

--- a/src/matrix/decomposition/svd.rs
+++ b/src/matrix/decomposition/svd.rs
@@ -254,7 +254,7 @@ impl<T: Any + Float + Signed> Matrix<T> {
             }
         }
 
-        let c_eigs = try!(c.eigenvalues());
+        let c_eigs = try!(c.clone().eigenvalues());
 
         // Choose eigenvalue closes to c[1,1].
         let lambda: T;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -599,7 +599,7 @@ impl<T: Any + Float> Matrix<T> {
     ///
     /// - The matrix cannot be decomposed into an LUP form to solve.
     /// - There is no valid solution as the matrix is singular.
-    pub fn solve(&self, y: Vector<T>) -> Result<Vector<T>, Error> {
+    pub fn solve(self, y: Vector<T>) -> Result<Vector<T>, Error> {
         let (l, u, p) = try!(self.lup_decomp());
 
         let b = try!(forward_substitution(&l, p * y));
@@ -614,7 +614,7 @@ impl<T: Any + Float> Matrix<T> {
     /// use rulinalg::matrix::Matrix;
     ///
     /// let a = Matrix::new(2,2, vec![2.,3.,1.,2.]);
-    /// let inv = a.inverse().expect("This matrix should have an inverse!");
+    /// let inv = a.clone().inverse().expect("This matrix should have an inverse!");
     ///
     /// let I = a * inv;
     ///
@@ -629,8 +629,10 @@ impl<T: Any + Float> Matrix<T> {
     ///
     /// - The matrix could not be LUP decomposed.
     /// - The matrix has zero determinant.
-    pub fn inverse(&self) -> Result<Matrix<T>, Error> {
-        assert!(self.rows == self.cols, "Matrix is not square.");
+    pub fn inverse(self) -> Result<Matrix<T>, Error> {
+        let rows = self.rows;
+        let cols = self.cols;
+        assert!(rows == cols, "Matrix is not square.");
 
         let mut inv_t_data = Vec::<T>::new();
         let (l, u, p) = try!(self.lup_decomp().map_err(|_| {
@@ -652,8 +654,8 @@ impl<T: Any + Float> Matrix<T> {
                                   "Matrix is singular and cannot be inverted."));
         }
 
-        for i in 0..self.rows {
-            let mut id_col = vec![T::zero(); self.cols];
+        for i in 0..rows {
+            let mut id_col = vec![T::zero(); cols];
             id_col[i] = T::one();
 
             let b = forward_substitution(&l, &p * Vector::new(id_col))
@@ -664,7 +666,7 @@ impl<T: Any + Float> Matrix<T> {
 
         }
 
-        Ok(Matrix::new(self.rows, self.cols, inv_t_data).transpose())
+        Ok(Matrix::new(rows, cols, inv_t_data).transpose())
     }
 
     /// Computes the determinant of the matrix.
@@ -685,7 +687,7 @@ impl<T: Any + Float> Matrix<T> {
     /// # Panics
     ///
     /// - The matrix is not square.
-    pub fn det(&self) -> T {
+    pub fn det(self) -> T {
         assert!(self.rows == self.cols, "Matrix is not square.");
 
         let n = self.cols;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -38,7 +38,7 @@ pub enum Axes {
 /// The `Matrix` struct.
 ///
 /// Can be instantiated with any type.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Matrix<T> {
     rows: usize,
     cols: usize,
@@ -348,17 +348,6 @@ impl<T> Matrix<T> {
     /// Consumes the Matrix and returns the Vec of data.
     pub fn into_vec(self) -> Vec<T> {
         self.data
-    }
-}
-
-impl<T: Clone> Clone for Matrix<T> {
-    /// Clones the Matrix.
-    fn clone(&self) -> Matrix<T> {
-        Matrix {
-            rows: self.rows,
-            cols: self.cols,
-            data: self.data.clone(),
-        }
     }
 }
 

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -64,7 +64,7 @@ fn matrix_lup_decomp() {
                     0., 0., 0., 6., 5.;
                     0., 0., 0., 5., 6.);
 
-    let (l, u, p) = b.lup_decomp().expect("Matrix SHOULD be able to be decomposed...");
+    let (l, u, p) = b.clone().lup_decomp().expect("Matrix SHOULD be able to be decomposed...");
     let k = p.transpose() * l * u;
 
     for i in 0..25 {


### PR DESCRIPTION
This PR is part of our series of breaking change updates coming with 0.4.

It is bad practice to clone `self` in a function taking `&self`. This PR resolves #91 and similar situations.