### PR TITLE
PERF: Improve perf of matrix.sum_rows

### DIFF
--- a/benches/linalg/matrix.rs
+++ b/benches/linalg/matrix.rs
@@ -1,4 +1,4 @@
-use rulinalg::matrix::Matrix;
+use rulinalg::matrix::{Matrix, Axes};
 use rulinalg::matrix::{BaseMatrix, BaseMatrixMut};
 use test::Bencher;
 use test::black_box;
@@ -146,5 +146,65 @@ fn mat_swap_cols_0_99(b: &mut Bencher) {
 
     b.iter(|| {
         black_box(m.swap_cols(0, 99));
+    });
+}
+
+#[bench]
+fn mat_sum_cols(b: &mut Bencher) {
+    let v = (0..100).collect::<Vec<_>>();
+    let mut data = Vec::with_capacity(10000);
+
+    for _ in 0..100 {
+        data.extend_from_slice(&v);
+    }
+    let m = Matrix::new(100, 100, data);
+
+    b.iter(|| {
+        black_box(m.sum_cols());
+    });
+}
+
+#[bench]
+fn mat_sum_rows(b: &mut Bencher) {
+    let v = (0..100).collect::<Vec<_>>();
+    let mut data = Vec::with_capacity(10000);
+
+    for _ in 0..100 {
+        data.extend_from_slice(&v);
+    }
+    let m = Matrix::new(100, 100, data);
+
+    b.iter(|| {
+        black_box(m.sum_rows());
+    });
+}
+
+#[bench]
+fn mat_mean_cols(b: &mut Bencher) {
+    let v = (0..100).map(|x| x as f64).collect::<Vec<_>>();
+    let mut data = Vec::with_capacity(10000);
+
+    for _ in 0..100 {
+        data.extend_from_slice(&v);
+    }
+    let m = Matrix::new(100, 100, data);
+
+    b.iter(|| {
+        black_box(m.mean(Axes::Col));
+    });
+}
+
+#[bench]
+fn mat_mean_rows(b: &mut Bencher) {
+    let v = (0..100).map(|x| x as f64).collect::<Vec<_>>();
+    let mut data = Vec::with_capacity(10000);
+
+    for _ in 0..100 {
+        data.extend_from_slice(&v);
+    }
+    let m = Matrix::new(100, 100, data);
+
+    b.iter(|| {
+        black_box(m.mean(Axes::Row));
     });
 }

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -312,9 +312,12 @@ pub trait BaseMatrix<T>: Sized {
     fn sum_rows(&self) -> Vector<T>
         where T: Copy + Zero + Add<T, Output = T>
     {
-        let sum_rows = self.row_iter().fold(vec![T::zero(); self.cols()], |row_sum, r| {
-            utils::vec_bin_op(&row_sum, r.raw_slice(), |sum, val| sum + val)
-        });
+        let mut sum_rows = vec![T::zero(); self.cols()];
+        for row in self.row_iter() {
+            for (sum, &r) in sum_rows.iter_mut().zip(row.raw_slice()) {
+                *sum = *sum + r;
+            }
+        }
         Vector::new(sum_rows)
     }
 
@@ -388,7 +391,7 @@ pub trait BaseMatrix<T>: Sized {
     /// assert_eq!(c, 2.0);
     /// # }
     /// ```
-    fn metric<'a, 'b, B, M>(&'a self, mat: &'b B, metric: M) -> T 
+    fn metric<'a, 'b, B, M>(&'a self, mat: &'b B, metric: M) -> T
         where B: 'b + BaseMatrix<T>, M: MatrixMetric<'a, 'b, T, Self, B>
     {
         metric.metric(self, mat)

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -314,9 +314,7 @@ pub trait BaseMatrix<T>: Sized {
     {
         let mut sum_rows = vec![T::zero(); self.cols()];
         for row in self.row_iter() {
-            for (sum, &r) in sum_rows.iter_mut().zip(row.raw_slice()) {
-                *sum = *sum + r;
-            }
+            utils::in_place_vec_bin_op(&mut sum_rows, row.raw_slice(), |sum, &r| *sum = *sum + r);
         }
         Vector::new(sum_rows)
     }


### PR DESCRIPTION
same impl as #115.

### Before

```
test linalg::matrix::mat_mean_cols                 ... bench:       8,800 ns/iter (+/- 200)
test linalg::matrix::mat_mean_rows                 ... bench:      18,792 ns/iter (+/- 2,265)
test linalg::matrix::mat_sum_cols                  ... bench:       4,915 ns/iter (+/- 1,770)
test linalg::matrix::mat_sum_rows                  ... bench:      12,735 ns/iter (+/- 1,606)
test linalg::matrix::mat_sum_rows_and_cols_128_100 ... bench:      27,507 ns/iter (+/- 9,377)
```

### After 

```
test linalg::matrix::mat_mean_cols                 ... bench:       9,528 ns/iter (+/- 3,713)
test linalg::matrix::mat_mean_rows                 ... bench:      15,885 ns/iter (+/- 4,485)
test linalg::matrix::mat_sum_cols                  ... bench:       4,939 ns/iter (+/- 1,895)
test linalg::matrix::mat_sum_rows                  ... bench:       8,343 ns/iter (+/- 1,591)
test linalg::matrix::mat_sum_rows_and_cols_128_100 ... bench:      21,615 ns/iter (+/- 3,500)
```