### PR TITLE
Added `vector![…]` macro mirroring `matrix![…]`

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -96,8 +96,8 @@ mod tests {
 
     #[test]
     fn inner_product_as_matrix_multiplication() {
-        let u: Vector<f32> = Vector::new(vec![1., 2., 3.]);
-        let v: Vector<f32> = Vector::new(vec![3., 4., 5.]);
+        let u: Vector<f32> = vector![1., 2., 3.];
+        let v: Vector<f32> = vector![3., 4., 5.];
         let dot_product = u.dot(&v);
 
         let um: Matrix<f32> = u.into();

--- a/src/macros/matrix_eq.rs
+++ b/src/macros/matrix_eq.rs
@@ -821,7 +821,6 @@ mod tests {
         MatrixComparisonResult,
         VectorComparisonResult};
     use matrix::Matrix;
-    use vector::Vector;
     use ulp::{Ulp, UlpComparisonResult};
     use quickcheck::TestResult;
     use std::f64;
@@ -1324,8 +1323,8 @@ mod tests {
 
             // It does not actually matter which comparator we use here, but we need to pick one
             let comp = ExactElementwiseComparator;
-            let ref x = Vector::new(vec![0; m]);
-            let ref y = Vector::new(vec![0; n]);
+            let ref x = vector![0; m];
+            let ref y = vector![0; n];
 
             let expected = VectorComparisonResult::MismatchedDimensions { dim_x: m, dim_y: n };
 
@@ -1336,7 +1335,7 @@ mod tests {
     quickcheck! {
         fn property_elementwise_vector_comparison_vector_matches_self(m: usize) -> bool {
             let comp = ExactElementwiseComparator;
-            let ref x = Vector::new(vec![0; m]);
+            let ref x = vector![0; m];
 
             elementwise_vector_comparison(x.data(), x.data(), comp) == VectorComparisonResult::Match
         }
@@ -1351,8 +1350,8 @@ mod tests {
 
         {
             // Single element vectors
-            let x = Vector::new(vec![1]);
-            let y = Vector::new(vec![2]);
+            let x = vector![1];
+            let y = vector![2];
 
             let expected = MismatchedElements {
                 comparator: comp,
@@ -1368,8 +1367,8 @@ mod tests {
 
         {
             // Mismatch for first and last elements of a vector
-            let x = Vector::new(vec![0, 1, 2]);
-            let y = Vector::new(vec![1, 1, 3]);
+            let x = vector![0, 1, 2];
+            let y = vector![1, 1, 3];
             let mismatches = vec![
                 VectorElementComparisonFailure {
                     x: 0, y: 1,
@@ -1393,8 +1392,8 @@ mod tests {
 
         {
             // Check some arbitrary elements
-            let x = Vector::new(vec![0, 1, 2, 3, 4, 5]);
-            let y = Vector::new(vec![0, 2, 2, 3, 5, 5]);
+            let x = vector![0, 1, 2, 3, 4, 5];
+            let y = vector![0, 2, 2, 3, 5, 5];
 
             let mismatches = vec![
                 VectorElementComparisonFailure {
@@ -1420,147 +1419,147 @@ mod tests {
 
     #[test]
     pub fn vector_eq_default_compare_self_for_integer() {
-        let x = Vector::new(vec![1, 2, 3 , 4]);
+        let x = vector![1, 2, 3 , 4];
         assert_vector_eq!(x, x);
     }
 
     #[test]
     pub fn vector_eq_default_compare_self_for_floating_point() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_default_mismatched_elements() {
-        let x = Vector::new(vec![1, 2, 3, 4]);
-        let y = Vector::new(vec![1, 2, 4, 4]);
+        let x = vector![1, 2, 3, 4];
+        let y = vector![1, 2, 4, 4];
         assert_vector_eq!(x, y);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_default_mismatched_dimensions() {
-        let x = Vector::new(vec![1, 2, 3, 4]);
-        let y = Vector::new(vec![1, 2, 3]);
+        let x = vector![1, 2, 3, 4];
+        let y = vector![1, 2, 3];
         assert_vector_eq!(x, y);
     }
 
     #[test]
     pub fn vector_eq_exact_compare_self_for_integer() {
-        let x = Vector::new(vec![1, 2, 3, 4]);
+        let x = vector![1, 2, 3, 4];
         assert_vector_eq!(x, x, comp = exact);
     }
 
     #[test]
     pub fn vector_eq_exact_compare_self_for_floating_point() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = exact);;
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_exact_mismatched_elements() {
-        let x = Vector::new(vec![1, 2, 3, 4]);
-        let y = Vector::new(vec![1, 2, 4, 4]);
+        let x = vector![1, 2, 3, 4];
+        let y = vector![1, 2, 4, 4];
         assert_vector_eq!(x, y, comp = exact);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_exact_mismatched_dimensions() {
-        let x = Vector::new(vec![1, 2, 3, 4]);
-        let y = Vector::new(vec![1, 2, 3]);
+        let x = vector![1, 2, 3, 4];
+        let y = vector![1, 2, 3];
         assert_vector_eq!(x, y, comp = exact);
     }
 
     #[test]
     pub fn vector_eq_abs_compare_self_for_integer() {
-        let x = Vector::new(vec![1, 2, 3, 4]);
+        let x = vector![1, 2, 3, 4];
         assert_vector_eq!(x, x, comp = abs, tol = 1);
     }
 
     #[test]
     pub fn vector_eq_abs_compare_self_for_floating_point() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = abs, tol = 1e-8);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_abs_mismatched_elements() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let y = Vector::new(vec![1.0, 2.0, 4.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
+        let y = vector![1.0, 2.0, 4.0, 4.0];
         assert_vector_eq!(x, y, comp = abs, tol = 1e-8);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_abs_mismatched_dimensions() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let y = Vector::new(vec![1.0, 2.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
+        let y = vector![1.0, 2.0, 4.0];
         assert_vector_eq!(x, y, comp = abs, tol = 1e-8);
     }
 
     #[test]
     pub fn vector_eq_ulp_compare_self() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = ulp, tol = 1);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_ulp_mismatched_elements() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let y = Vector::new(vec![1.0, 2.0, 4.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
+        let y = vector![1.0, 2.0, 4.0, 4.0];
         assert_vector_eq!(x, y, comp = ulp, tol = 4);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_ulp_mismatched_dimensions() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let y = Vector::new(vec![1.0, 2.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
+        let y = vector![1.0, 2.0, 4.0];
         assert_vector_eq!(x, y, comp = ulp, tol = 4);
     }
 
     #[test]
     pub fn vector_eq_float_compare_self() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = ulp, tol = 1);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_float_mismatched_elements() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let y = Vector::new(vec![1.0, 2.0, 4.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
+        let y = vector![1.0, 2.0, 4.0, 4.0];
         assert_vector_eq!(x, y, comp = float);
     }
 
     #[test]
     #[should_panic]
     pub fn vector_eq_float_mismatched_dimensions() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
-        let y = Vector::new(vec![1.0, 2.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
+        let y = vector![1.0, 2.0, 4.0];
         assert_vector_eq!(x, y, comp = float);
     }
 
     #[test]
     pub fn vector_eq_float_compare_self_with_eps() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = float, eps = 1e-6);
     }
 
     #[test]
     pub fn vector_eq_float_compare_self_with_ulp() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = float, ulp = 12);
     }
 
     #[test]
     pub fn vector_eq_float_compare_self_with_eps_and_ulp() {
-        let x = Vector::new(vec![1.0, 2.0, 3.0, 4.0]);
+        let x = vector![1.0, 2.0, 3.0, 4.0];
         assert_vector_eq!(x, x, comp = float, eps = 1e-6, ulp = 12);
         assert_vector_eq!(x, x, comp = float, ulp = 12, eps = 1e-6);
     }
@@ -1568,7 +1567,7 @@ mod tests {
     #[test]
     pub fn vector_eq_pass_by_ref()
     {
-        let x = Vector::new(vec![0.0]);
+        let x = vector![0.0];
 
         // Exercise all the macro definitions and make sure that we are able to call it
         // when the arguments are references.

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,6 +1,9 @@
 //! Macros for the linear algebra modules.
 
 #[macro_use]
+mod vector;
+
+#[macro_use]
 mod matrix;
 
 #[macro_use]

--- a/src/macros/vector.rs
+++ b/src/macros/vector.rs
@@ -1,0 +1,100 @@
+/// The `vector!` macro enables easy construction of small vectors.
+///
+/// This is particularly useful when writing tests involving vectors.
+/// Note that the macro is just a convenient wrapper around the Vector
+/// constructors, and as a result the vector is still allocated on the
+/// heap.
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use]
+/// extern crate rulinalg;
+///
+/// # fn main() {
+/// use rulinalg::vector::Vector;
+///
+/// // Construct a vector of f64
+/// let vec = vector![1.0, 2.0, 3.0];
+/// # }
+/// ```
+///
+/// To construct vectors of other types, specify the type by
+/// the usual Rust syntax:
+///
+/// ```
+/// #[macro_use]
+/// extern crate rulinalg;
+///
+/// # fn main() {
+/// use rulinalg::vector::Vector;
+///
+/// // Construct a vector of f32
+/// let vec: Vector<f32> = vector![1.0, 2.0, 3.0];
+/// // Or
+/// let vec = vector![1.0, 2.0, 3.0f32];
+/// # }
+/// ```
+///
+#[macro_export]
+macro_rules! vector {
+    () => {
+        {
+            // Handle the case when called with no arguments, i.e. vector![]
+            use $crate::vector::Vector;
+            Vector::new(vec![])
+        }
+    };
+    ($($x:expr),*) => {
+        {
+            use $crate::vector::Vector;
+            Vector::new(vec![$($x),*])
+        }
+    };
+    ($x:expr; $n:expr) => {
+        {
+            use $crate::vector::Vector;
+            Vector::new(vec![$x; $n])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vector::Vector;
+
+    #[test]
+    fn vector_macro() {
+        {
+            // An arbitrary vector
+            let vec = vector![1, 2, 3, 4, 5, 6];
+            assert_eq!(6, vec.size());
+            assert_eq!(&vec![1, 2, 3, 4, 5, 6], vec.data());
+        }
+
+        {
+            // A floating point vector
+            let vec = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+            let ref expected_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+            assert_eq!(6, vec.size());
+            assert_eq!(expected_data, vec.data());
+        }
+    }
+
+    #[test]
+    fn vector_macro_constant_size() {
+        // A constant size vector
+        let vec = vector![1.0; 5];
+        let ref expected_data = vec![1.0, 1.0, 1.0, 1.0, 1.0];
+        assert_eq!(5, vec.size());
+        assert_eq!(expected_data, vec.data());
+    }
+
+    #[test]
+    fn vector_macro_empty_vec() {
+        let vec: Vector<f64> = vector![];
+
+        assert_eq!(0, vec.size());
+    }
+
+}

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -388,7 +388,7 @@ pub trait BaseMatrix<T>: Sized {
     /// assert_eq!(c, 2.0);
     /// # }
     /// ```
-    fn metric<'a, 'b, B, M>(&'a self, mat: &'b B, metric: M) -> T 
+    fn metric<'a, 'b, B, M>(&'a self, mat: &'b B, metric: M) -> T
         where B: 'b + BaseMatrix<T>, M: MatrixMetric<'a, 'b, T, Self, B>
     {
         metric.metric(self, mat)

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -361,7 +361,6 @@ impl<T: Any + Float + Signed> Matrix<T> {
 #[cfg(test)]
 mod tests {
     use matrix::Matrix;
-    use vector::Vector;
 
     #[test]
     fn test_1_by_1_matrix_eigenvalues() {
@@ -402,8 +401,8 @@ mod tests {
         let lambda_1 = eigenvals[0];
         let lambda_2 = eigenvals[1];
 
-        let v1 = Vector::new(vec![eigenvecs[[0, 0]], eigenvecs[[1, 0]]]);
-        let v2 = Vector::new(vec![eigenvecs[[0, 1]], eigenvecs[[1, 1]]]);
+        let v1 = vector![eigenvecs[[0, 0]], eigenvecs[[1, 0]]];
+        let v2 = vector![eigenvecs[[0, 1]], eigenvecs[[1, 1]]];
 
         let epsilon = 0.00001;
         assert!((&a * &v1 - &v1 * lambda_1).into_vec().iter().all(|&c| c < epsilon));

--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -540,7 +540,6 @@ impl<T: fmt::Display> fmt::Display for Matrix<T> {
 
 #[cfg(test)]
 mod tests {
-    use vector::Vector;
     use matrix::{Axes, BaseMatrix, Matrix};
     use libnum::abs;
 
@@ -729,7 +728,7 @@ mod tests {
         let a = matrix!(2., 3.;
                         1., 2.);
 
-        let y = Vector::new(vec![8., 5.]);
+        let y = vector![8., 5.];
 
         let x = a.solve(y).unwrap();
 

--- a/src/matrix/impl_ops.rs
+++ b/src/matrix/impl_ops.rs
@@ -888,8 +888,7 @@ mod tests {
     use super::super::Matrix;
     use super::super::MatrixSlice;
     use super::super::MatrixSliceMut;
-    use super::super::super::vector::Vector;
-
+    
     #[test]
     fn indexing_mat() {
         let a = matrix!(1., 2.;
@@ -909,7 +908,7 @@ mod tests {
         let a = matrix!(1., 2.;
                         3., 4.;
                         5., 6.);
-        let b = Vector::new(vec![4., 7.]);
+        let b = vector![4., 7.];
 
         let c = a * b;
 

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_euclidean_vector_norm() {
-        let v = Vector::new(vec![3.0, 4.0]);
+        let v = vector![3.0, 4.0];
         assert!((VectorNorm::norm(&Euclidean, &v) - 5.0) < 1e-14);
     }
 
@@ -242,21 +242,21 @@ mod tests {
 
     #[test]
     fn test_euclidean_vector_metric() {
-        let v = Vector::new(vec![3.0, 4.0]);
+        let v = vector![3.0, 4.0];
         assert!((VectorMetric::metric(&Euclidean, &v, &v)) < 1e-14);
 
-        let v1 = Vector::new(vec![0.0, 0.0]);
+        let v1 = vector![0.0, 0.0];
         assert!((VectorMetric::metric(&Euclidean, &v, &v1) - 5.0) < 1e-14);
 
-        let v2 = Vector::new(vec![4.0, 3.0]);
+        let v2 = vector![4.0, 3.0];
         assert!((VectorMetric::metric(&Euclidean, &v, &v2) - 2.0.sqrt()) < 1e-14);
     }
 
     #[test]
     #[should_panic]
     fn test_euclidean_vector_metric_bad_dim() {
-        let v = Vector::new(vec![3.0, 4.0]);
-        let v2 = Vector::new(vec![1.0, 2.0, 3.0]);
+        let v = vector![3.0, 4.0];
+        let v2 = vector![1.0, 2.0, 3.0];
 
         VectorMetric::metric(&Euclidean, &v, &v2);
     }
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_lp_vector_supremum() {
-        let v = Vector::new(vec![-5.0, 3.0]);
+        let v = vector![-5.0, 3.0];
 
         let sup = VectorNorm::norm(&Lp::Infinity, &v);
         assert_eq!(sup, 5.0);
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_lp_vector_one() {
-        let v = Vector::new(vec![1.0, 2.0, -2.0]);
+        let v = vector![1.0, 2.0, -2.0];
         assert_eq!(VectorNorm::norm(&Lp::Integer(1), &v), 5.0);
     }
 
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_lp_vector_float() {
-        let v = Vector::new(vec![1.0, 2.0, -2.0]);
+        let v = vector![1.0, 2.0, -2.0];
         assert_eq!(VectorNorm::norm(&Lp::Float(1.0), &v), 5.0);
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -847,24 +847,24 @@ mod tests {
 
     #[test]
     fn test_display() {
-        let v = Vector::new(vec![1, 2, 3, 4]);
+        let v = vector![1, 2, 3, 4];
         assert_eq!(format!("{}", v), "[ 1, 2, 3, 4]");
 
-        let v2 = Vector::new(vec![3.3, 4.0, 5.0, 6.0]);
+        let v2 = vector![3.3, 4.0, 5.0, 6.0];
         assert_eq!(format!("{}", v2), "[ 3.3, 4, 5, 6]");
         assert_eq!(format!("{:.1}", v2), "[ 3.3, 4.0, 5.0, 6.0]");
     }
 
     #[test]
     fn test_equality() {
-        let v = Vector::new(vec![1, 2, 3, 4]);
+        let v = vector![1, 2, 3, 4];
         let v_redux = v.clone();
         assert_eq!(v, v_redux);
     }
 
     #[test]
     fn create_vector_new() {
-        let a = Vector::new(vec![1.0; 12]);
+        let a = vector![1.0; 12];
 
         assert_eq!(a.size(), 12);
 
@@ -885,17 +885,17 @@ mod tests {
     #[test]
     fn create_vector_from_fn() {
         let v1 = Vector::from_fn(3, |x| x + 1);
-        assert_eq!(v1, Vector::new(vec![1, 2, 3]));
+        assert_eq!(v1, vector![1, 2, 3]);
 
         let v2 = Vector::from_fn(3, |x| x as f64);
-        assert_eq!(v2, Vector::new(vec![0., 1., 2.]));
+        assert_eq!(v2, vector![0., 1., 2.]);
 
         let mut z = 0;
         let v3 = Vector::from_fn(3, |x| { z += 1; x + z });
-        assert_eq!(v3, Vector::new(vec![0 + 1, 1 + 2, 2 + 3]));
+        assert_eq!(v3, vector![0 + 1, 1 + 2, 2 + 3]);
 
         let v4 = Vector::from_fn(3, move |x| x + 1);
-        assert_eq!(v4, Vector::new(vec![1, 2, 3]));
+        assert_eq!(v4, vector![1, 2, 3]);
 
         let v5 = Vector::from_fn(0, |x| x);
         assert_eq!(v5, Vector::new(vec![]));
@@ -914,8 +914,8 @@ mod tests {
 
     #[test]
     fn vector_dot_product() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-        let b = Vector::new(vec![3.0; 6]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let b = vector![3.0; 6];
 
         let c = a.dot(&b);
 
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     fn vector_f32_mul() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let b = 3.0;
 
         // Allocating new memory
@@ -958,7 +958,7 @@ mod tests {
 
     #[test]
     fn vector_f32_div() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let b = 3.0;
 
         // Allocating new memory
@@ -992,8 +992,8 @@ mod tests {
 
     #[test]
     fn vector_add() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-        let b = Vector::new(vec![2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let b = vector![2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
 
         // Allocating new memory
         let c = &a + &b;
@@ -1026,7 +1026,7 @@ mod tests {
 
     #[test]
     fn vector_f32_add() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let b = 2.0;
 
         // Allocating new memory
@@ -1060,8 +1060,8 @@ mod tests {
 
     #[test]
     fn vector_sub() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-        let b = Vector::new(vec![2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let b = vector![2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
 
         // Allocating new memory
         let c = &a - &b;
@@ -1094,7 +1094,7 @@ mod tests {
 
     #[test]
     fn vector_f32_sub() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let b = 2.0;
 
         // Allocating new memory
@@ -1128,7 +1128,7 @@ mod tests {
 
     #[test]
     fn vector_euclidean_norm() {
-        let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let a = vector![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 
         let b = a.norm(Euclidean);
 
@@ -1234,12 +1234,12 @@ mod tests {
     #[test]
     fn vector_from_iter() {
         let v1: Vector<usize> = (2..5).collect();
-        let exp1 = Vector::new(vec![2, 3, 4]);
+        let exp1 = vector![2, 3, 4];
         assert_eq!(v1, exp1);
 
         let orig: Vec<f64> = vec![2., 3., 4.];
         let v2: Vector<f64> = orig.iter().map(|x| x + 1.).collect();
-        let exp2 = Vector::new(vec![3., 4., 5.]);
+        let exp2 = vector![3., 4., 5.];
         assert_eq!(v2, exp2);
     }
 
@@ -1257,17 +1257,17 @@ mod tests {
 
     #[test]
     fn vector_get_unchecked() {
-        let v1 = Vector::new(vec![1, 2, 3]);
+        let v1 = vector![1, 2, 3];
         unsafe {
             assert_eq!(v1.get_unchecked(1), &2);
         }
 
-        let mut v2 = Vector::new(vec![1, 2, 3]);
+        let mut v2 = vector![1, 2, 3];
 
         unsafe {
             let elem = v2.get_unchecked_mut(1);
             *elem = 4;
         }
-        assert_eq!(v2, Vector::new(vec![1, 4, 3]));
+        assert_eq!(v2, vector![1, 4, 3]);
     }
 }

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -1,4 +1,3 @@
-use rulinalg::vector::Vector;
 use rulinalg::matrix::{BaseMatrix, Matrix};
 
 #[test]
@@ -13,12 +12,12 @@ fn test_solve() {
                     0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 1.0;
                     0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
 
-    let b = Vector::new(vec![-100.0, 0.0, 0.0, -100.0, 0.0, 0.0, -100.0, 0.0, 0.0]);
+    let b = vector![-100.0, 0.0, 0.0, -100.0, 0.0, 0.0, -100.0, 0.0, 0.0];
 
     let c = a.solve(b).unwrap();
     let true_solution = vec![42.85714286, 18.75, 7.14285714, 52.67857143,
                              25.0, 9.82142857, 42.85714286, 18.75, 7.14285714];
-    
+
     assert!(c.into_iter().zip(true_solution.into_iter()).all(|(x, y)| (x-y) < 1e-5));
 
 }
@@ -26,19 +25,19 @@ fn test_solve() {
 #[test]
 fn test_l_triangular_solve_errs() {
     let a: Matrix<f64> = matrix!();
-    assert!(a.solve_l_triangular(Vector::new(vec![])).is_err());
+    assert!(a.solve_l_triangular(vector![]).is_err());
 
     let a = matrix!(0.0);
-    assert!(a.solve_l_triangular(Vector::new(vec![1.0])).is_err());
+    assert!(a.solve_l_triangular(vector![1.0]).is_err());
 }
 
 #[test]
 fn test_u_triangular_solve_errs() {
     let a: Matrix<f64> = matrix!();
-    assert!(a.solve_u_triangular(Vector::new(vec![])).is_err());
+    assert!(a.solve_u_triangular(vector![]).is_err());
 
     let a = matrix!(0.0);
-    assert!(a.solve_u_triangular(Vector::new(vec![1.0])).is_err());
+    assert!(a.solve_u_triangular(vector![1.0]).is_err());
 }
 
 #[test]


### PR DESCRIPTION
We have a `matrix!` macro for ergonomic matrix declarations. Vector should have the same, imho.