### PR TITLE
Added `fn from_fn` for `Vector` mirroring `Matrix`’s `fn from_fn`

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -43,6 +43,31 @@ impl<T> Vector<T> {
         }
     }
 
+    /// Constructor for Vector struct that takes a function `f`
+    /// and constructs a new vector such that `X_i = f(i)`,
+    /// where `i` is the index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rulinalg::vector::Vector;
+    ///
+    /// // Let's assume you have function (such as `sin(x)`) based upon
+    /// // which you want to generate a vector:
+    /// let vector: Vector<f64> = Vector::from_fn(10, |idx| {
+    ///     (idx as f64).sin()
+    /// });
+    /// ```
+    pub fn from_fn<F>(size: usize, mut f: F) -> Vector<T>
+        where F: FnMut(usize) -> T
+    {
+        let mut data = Vec::with_capacity(size);
+        for idx in 0..size {
+            data.push(f(idx));
+        }
+        Vector::new(data)
+    }
+
     /// Returns the size of the Vector.
     pub fn size(&self) -> usize {
         self.size


### PR DESCRIPTION
The motivation basically is the same as the one behind https://github.com/AtheMathmo/rulinalg/pull/43.

Basically (similar to `Matrix`) I find myself frequently needing to construct a vector by calculating its values from external data, most notably in the form of weights. The `Vector::from_fn` aims to provide a convenience constructor for these scenarios while encapsulating the vector's internal representation.