### PR TITLE
Ignore Eclipse ".project" file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 .vscode
 *.rs.bk
 .DS_Store
+.project


### PR DESCRIPTION
Eclipse automatically creates a file named ".project" for every single project, just like Visual Studio Code creates a ".vscode" file for workspace settings.