### PR TITLE
DOC: use macros

### DIFF
--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -428,16 +428,15 @@ pub trait BaseMatrix<T>: Sized {
     /// ```
     /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix, Axes};
-    /// use rulinalg::vector::Vector;
     ///
     /// let a = matrix![1.0, 2.0;
     ///                 3.0, 4.0];
     ///
     /// let cmin = a.min(Axes::Col);
-    /// assert_eq!(cmin, Vector::new(vec![1.0, 3.0]));
+    /// assert_eq!(cmin, vector![1.0, 3.0]);
     ///
     /// let rmin = a.min(Axes::Row);
-    /// assert_eq!(rmin, Vector::new(vec![1.0, 2.0]));
+    /// assert_eq!(rmin, vector![1.0, 2.0]);
     /// # }
     /// ```
     fn min(&self, axis: Axes) -> Vector<T> where T: Copy + PartialOrd
@@ -470,8 +469,7 @@ pub trait BaseMatrix<T>: Sized {
     ///
     /// ```
     /// # #[macro_use] extern crate rulinalg; fn main() {
-    /// use rulinalg::matrix::{Matrix, BaseMatrix, Axes};
-    /// use rulinalg::vector::Vector;
+    /// use rulinalg::matrix::{BaseMatrix, Axes};
     ///
     /// let a = matrix![1.0, 2.0;
     ///                 3.0, 4.0];
@@ -624,7 +622,7 @@ pub trait BaseMatrix<T>: Sized {
     ///                 3.0, 4.0];
     ///
     /// let c = &a.elemul(&b);
-    /// assert_eq!(c, &matrix![1.0, 4.0; 9.0, 16.0]);
+    /// assert_matrix_eq!(c, &matrix![1.0, 4.0; 9.0, 16.0]);
     /// }
     /// ```
     ///
@@ -659,7 +657,7 @@ pub trait BaseMatrix<T>: Sized {
     ///                 3.0, 4.0];
     ///
     /// let c = &a.elediv(&b);
-    /// assert_eq!(c, &matrix![1.0, 1.0; 1.0, 1.0]);
+    /// assert_matrix_eq!(c, &matrix![1.0, 1.0; 1.0, 1.0]);
     /// # }
     /// ```
     ///
@@ -694,7 +692,7 @@ pub trait BaseMatrix<T>: Sized {
     /// assert_eq!(b.rows(), 2);
     /// assert_eq!(b.cols(), 2);
     ///
-    /// // Prints [0,0,1,0]
+    /// // Prints [0,0, 1,0]
     /// println!("{:?}", b.data());
     /// ```
     ///
@@ -825,8 +823,7 @@ pub trait BaseMatrix<T>: Sized {
     /// # #[macro_use]
     /// # extern crate rulinalg;
     ///
-    /// use rulinalg::vector::Vector;
-    /// use rulinalg::matrix::{Matrix, BaseMatrix};
+    /// use rulinalg::matrix::BaseMatrix;
     ///
     /// # fn main() {
     /// let a = matrix![1, 2, 3;
@@ -855,7 +852,10 @@ pub trait BaseMatrix<T>: Sized {
     /// let mat = matrix![1.0, 2.0, 3.0;
     ///                   4.0, 5.0, 6.0];
     ///
-    /// let mt = mat.transpose();
+    /// let expected = matrix![1.0, 4.0;
+    ///                        2.0, 5.0;
+    ///                        3.0, 6.0];
+    /// assert_matrix_eq!(mat.transpose(), expected);
     /// # }
     /// ```
     fn transpose(&self) -> Matrix<T>
@@ -922,8 +922,7 @@ pub trait BaseMatrix<T>: Sized {
     ///
     /// ```
     /// # #[macro_use] extern crate rulinalg; fn main() {
-    /// use rulinalg::matrix::{Matrix, BaseMatrix};
-    /// use rulinalg::vector::Vector;
+    /// use rulinalg::matrix::BaseMatrix;
     /// use std::f32;
     ///
     /// let u = matrix![1.0, 2.0;
@@ -965,8 +964,7 @@ pub trait BaseMatrix<T>: Sized {
     ///
     /// ```
     /// # #[macro_use] extern crate rulinalg; fn main() {
-    /// use rulinalg::matrix::{Matrix, BaseMatrix};
-    /// use rulinalg::vector::Vector;
+    /// use rulinalg::matrix::BaseMatrix;
     /// use std::f32;
     ///
     /// let l = matrix![1.0, 0.0;
@@ -1104,6 +1102,7 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrixMut};
     ///
     /// let mut a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
@@ -1117,7 +1116,8 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// }
     ///
     /// // Only the matrix slice is updated.
-    /// assert_eq!(a.into_vec(), vec![0, 1, 2, 3, 6, 7, 6, 9, 10]);
+    /// assert_matrix_eq!(a, matrix![0, 1, 2; 3, 6, 7; 6, 9, 10]);
+    /// # }
     /// ```
     fn iter_mut<'a>(&mut self) -> SliceIterMut<'a, T>
         where T: 'a
@@ -1480,6 +1480,7 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrixMut};
     ///
     /// fn add_two(a: f64) -> f64 {
@@ -1490,7 +1491,8 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     ///
     /// let b = a.apply(&add_two);
     ///
-    /// assert_eq!(*b.data(), vec![2.0; 4]);
+    /// assert_eq!(b, matrix![2.0, 2.0; 2.0, 2.0]);
+    /// # }
     /// ```
     fn apply(mut self, f: &Fn(T) -> T) -> Self
         where T: Copy

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -191,10 +191,10 @@ pub trait BaseMatrix<T>: Sized {
     /// let mat = matrix![0, 1, 2;
     ///                   3, 4, 5;
     ///                   6, 7, 8];
-    /// let slice = mat.sub_slice([1,1], 2, 2);
+    /// let slice = mat.sub_slice([1, 1], 2, 2);
     ///
     /// let slice_data = slice.iter().map(|v| *v).collect::<Vec<usize>>();
-    /// assert_eq!(slice_data, vec![4,5,7,8]);
+    /// assert_eq!(slice_data, vec![4, 5, 7, 8]);
     /// # }
     /// ```
     fn iter<'a>(&self) -> SliceIter<'a, T>
@@ -302,12 +302,15 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = a.sum_rows();
-    /// assert_eq!(*c.data(), vec![4.0, 6.0]);
+    /// assert_eq!(c, vector![4.0, 6.0]);
+    /// # }
     /// ```
     fn sum_rows(&self) -> Vector<T>
         where T: Copy + Zero + Add<T, Output = T>
@@ -336,7 +339,7 @@ pub trait BaseMatrix<T>: Sized {
     ///                 3.0, 4.0];
     ///
     /// let c = a.sum_cols();
-    /// assert_eq!(*c.data(), vec![3.0, 7.0]);
+    /// assert_eq!(c, vector![3.0, 7.0]);
     /// # }
     /// ```
     fn sum_cols(&self) -> Vector<T>
@@ -612,13 +615,17 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
-    /// let b = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
+    /// let b = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = &a.elemul(&b);
-    /// assert_eq!(*c.data(), vec![1.0, 4.0, 9.0, 16.0]);
+    /// assert_eq!(c, &matrix![1.0, 4.0; 9.0, 16.0]);
+    /// }
     /// ```
     ///
     /// # Panics
@@ -643,13 +650,17 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
-    /// let b = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
+    /// let b = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = &a.elediv(&b);
-    /// assert_eq!(*c.data(), vec![1.0; 4]);
+    /// assert_eq!(c, &matrix![1.0, 1.0; 1.0, 1.0]);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -726,14 +737,20 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(3,2, vec![1.0,2.0,3.0,4.0,5.0,6.0]);
-    /// let b = Matrix::new(3,1, vec![4.0,5.0,6.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0;
+    ///                 5.0, 6.0];
+    /// let b = matrix![4.0;
+    ///                 5.0;
+    ///                 6.0];
     ///
     /// let c = &a.hcat(&b);
     /// assert_eq!(c.cols(), a.cols() + b.cols());
     /// assert_eq!(c[[1, 2]], 5.0);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -764,14 +781,17 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(2,3, vec![1.0,2.0,3.0,4.0,5.0,6.0]);
-    /// let b = Matrix::new(1,3, vec![4.0,5.0,6.0]);
+    /// let a = matrix![1.0, 2.0, 3.0;
+    ///                 4.0, 5.0, 6.0];
+    /// let b = matrix![4.0, 5.0, 6.0];;
     ///
     /// let c = &a.vcat(&b);
     /// assert_eq!(c.rows(), a.rows() + b.rows());
     /// assert_eq!(c[[2, 2]], 6.0);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -829,11 +849,14 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let mat = Matrix::new(2,3, vec![1.0,2.0,3.0,4.0,5.0,6.0]);
+    /// let mat = matrix![1.0, 2.0, 3.0;
+    ///                   4.0, 5.0, 6.0];
     ///
     /// let mt = mat.transpose();
+    /// # }
     /// ```
     fn transpose(&self) -> Matrix<T>
         where T: Copy
@@ -861,17 +884,21 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(2,2, vec![1.0,0.0,0.0,1.0]);
+    /// let a = matrix![1.0, 0.0;
+    ///                 0.0, 1.0];
     /// let a_diag = a.is_diag();
     ///
     /// assert_eq!(a_diag, true);
     ///
-    /// let b = Matrix::new(2,2, vec![1.0,0.0,1.0,0.0]);
+    /// let b = matrix![1.0, 0.0;
+    ///                 1.0, 0.0];
     /// let b_diag = b.is_diag();
     ///
     /// assert_eq!(b_diag, false);
+    /// # }
     /// ```
     fn is_diag(&self) -> bool
         where T: Zero + PartialEq
@@ -894,16 +921,19 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     /// use rulinalg::vector::Vector;
     /// use std::f32;
     ///
-    /// let u = Matrix::new(2,2, vec![1.0, 2.0, 0.0, 1.0]);
-    /// let y = Vector::new(vec![3.0, 1.0]);
+    /// let u = matrix![1.0, 2.0;
+    ///                 0.0, 1.0];
+    /// let y = vector![3.0, 1.0];
     ///
     /// let x = u.solve_u_triangular(y).expect("A solution should exist!");
     /// assert!((x[0] - 1.0) < f32::EPSILON);
     /// assert!((x[1] - 1.0) < f32::EPSILON);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -934,17 +964,20 @@ pub trait BaseMatrix<T>: Sized {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     /// use rulinalg::vector::Vector;
     /// use std::f32;
     ///
-    /// let l = Matrix::new(2,2, vec![1.0, 0.0, 2.0, 1.0]);
-    /// let y = Vector::new(vec![1.0, 3.0]);
+    /// let l = matrix![1.0, 0.0;
+    ///                 2.0, 1.0];
+    /// let y = vector![1.0, 3.0];
     ///
     /// let x = l.solve_l_triangular(y).expect("A solution should exist!");
     /// println!("{:?}", x);
     /// assert!((x[0] - 1.0) < f32::EPSILON);
     /// assert!((x[1] - 1.0) < f32::EPSILON);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -1084,7 +1117,7 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// }
     ///
     /// // Only the matrix slice is updated.
-    /// assert_eq!(a.into_vec(), vec![0,1,2,3,6,7,6,9,10]);
+    /// assert_eq!(a.into_vec(), vec![0, 1, 2, 3, 6, 7, 6, 9, 10]);
     /// ```
     fn iter_mut<'a>(&mut self) -> SliceIterMut<'a, T>
         where T: 'a
@@ -1476,7 +1509,7 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     /// use rulinalg::matrix::{Axes, Matrix, BaseMatrixMut};
     ///
     /// let mut a = Matrix::new(3,3, vec![2.0; 9]);
-    /// let (b,c) = a.split_at_mut(1, Axes::Col);
+    /// let (b, c) = a.split_at_mut(1, Axes::Col);
     /// ```
     fn split_at_mut(&mut self, mid: usize, axis: Axes) -> (MatrixSliceMut<T>, MatrixSliceMut<T>) {
 

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -15,11 +15,15 @@ impl<T> Matrix<T>
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     ///
-    /// let m = Matrix::new(3,3, vec![1.0,0.5,0.5,0.5,1.0,0.5,0.5,0.5,1.0]);
+    /// let m = matrix![1.0, 0.5, 0.5;
+    ///                 0.5, 1.0, 0.5;
+    ///                 0.5, 0.5, 1.0];
     ///
     /// let l = m.cholesky();
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -330,13 +330,17 @@ impl<T: Any + Float + Signed> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     ///
-    /// let a = Matrix::new(3,3,vec![3.,2.,4.,2.,0.,2.,4.,2.,3.]);
+    /// let a = matrix![3., 2., 4.;
+    ///                 2., 0., 2.;
+    ///                 4., 2., 3.];
     ///
     /// let (e, m) = a.eigendecomp().expect("We should be able to compute this eigendecomp!");
     /// println!("{:?}", e);
     /// println!("{:?}", m.data());
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/src/matrix/decomposition/hessenberg.rs
+++ b/src/matrix/decomposition/hessenberg.rs
@@ -23,7 +23,7 @@ impl<T: Any + Float> Matrix<T> {
     ///                 2., 0., 1., 1.];
     /// let h = a.upper_hessenberg();
     ///
-    /// println!("{:?}", h.expect("Could not get upper Hessenberg form.").data());
+    /// println!("{:}", h.expect("Could not get upper Hessenberg form."));
     /// # }
     /// ```
     ///
@@ -91,17 +91,16 @@ impl<T: Any + Float> Matrix<T> {
     ///
     /// ```
     /// # #[macro_use] extern crate rulinalg; fn main() {
-    /// use rulinalg::matrix::{Matrix, BaseMatrix};
+    /// use rulinalg::matrix::BaseMatrix;
     ///
     /// let a = matrix![1., 2., 3.;
     ///                 4., 5., 6.;
     ///                 7., 8., 9.];
     ///
     /// // u is the transform, h is the upper hessenberg form.
-    /// let (u,h) = a.clone().upper_hess_decomp().expect("This matrix should decompose!");
+    /// let (u, h) = a.clone().upper_hess_decomp().expect("This matrix should decompose!");
     ///
-    /// println!("The hess : {:?}", h.data());
-    /// println!("Manual hess : {:?}", (u.transpose() * a * u).data());
+    /// assert_matrix_eq!(h, u.transpose() * a * u, comp = abs, tol = 1e-12);
     /// # }
     /// ```
     ///

--- a/src/matrix/decomposition/hessenberg.rs
+++ b/src/matrix/decomposition/hessenberg.rs
@@ -14,12 +14,17 @@ impl<T: Any + Float> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     ///
-    /// let a = Matrix::new(4,4,vec![2.,0.,1.,1.,2.,0.,1.,2.,1.,2.,0.,0.,2.,0.,1.,1.]);
+    /// let a = matrix![2., 0., 1., 1.;
+    ///                 2., 0., 1., 2.;
+    ///                 1., 2., 0., 0.;
+    ///                 2., 0., 1., 1.];
     /// let h = a.upper_hessenberg();
     ///
     /// println!("{:?}", h.expect("Could not get upper Hessenberg form.").data());
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -85,15 +90,19 @@ impl<T: Any + Float> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let a = Matrix::new(3,3,vec![1.,2.,3.,4.,5.,6.,7.,8.,9.]);
+    /// let a = matrix![1., 2., 3.;
+    ///                 4., 5., 6.;
+    ///                 7., 8., 9.];
     ///
     /// // u is the transform, h is the upper hessenberg form.
     /// let (u,h) = a.clone().upper_hess_decomp().expect("This matrix should decompose!");
     ///
     /// println!("The hess : {:?}", h.data());
     /// println!("Manual hess : {:?}", (u.transpose() * a * u).data());
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -14,13 +14,15 @@ impl<T> Matrix<T> where T: Any + Float
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     ///
-    /// let a = Matrix::new(3,3, vec![1.0,2.0,0.0,
-    ///                               0.0,3.0,4.0,
-    ///                               5.0, 1.0, 2.0]);
+    /// let a = matrix![1.0, 2.0, 0.0;
+    ///                 0.0, 3.0, 4.0;
+    ///                 5.0, 1.0, 2.0];
     ///
-    /// let (l,u,p) = a.lup_decomp().expect("This matrix should decompose!");
+    /// let (l, u, p) = a.lup_decomp().expect("This matrix should decompose!");
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/src/matrix/decomposition/qr.rs
+++ b/src/matrix/decomposition/qr.rs
@@ -15,11 +15,15 @@ impl<T> Matrix<T>
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     ///
-    /// let m = Matrix::new(3,3, vec![1.0,0.5,0.5,0.5,1.0,0.5,0.5,0.5,1.0]);
+    /// let m = matrix![1.0, 0.5, 0.5;
+    ///                 0.5, 1.0, 0.5;
+    ///                 0.5, 0.5, 1.0];
     ///
     /// let (q, r) = m.qr_decomp().unwrap();
+    /// # }
     /// ```
     ///
     /// # Failures

--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -361,7 +361,7 @@ impl<T: Any + Float> Matrix<T> {
     ///
     /// let I = a * inv;
     ///
-    /// assert_eq!(I, matrix![1.0, 0.0; 0.0, 1.0]);
+    /// assert_matrix_eq!(I, matrix![1.0, 0.0; 0.0, 1.0]);
     /// # }
     /// ```
     ///

--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -18,7 +18,7 @@ impl<T> Matrix<T> {
     /// ```
     /// use rulinalg::matrix::{Matrix, BaseMatrix};
     ///
-    /// let mat = Matrix::new(2,2, vec![1.0,2.0,3.0,4.0]);
+    /// let mat = Matrix::new(2,2, vec![1.0, 2.0, 3.0, 4.0]);
     ///
     /// assert_eq!(mat.rows(), 2);
     /// assert_eq!(mat.cols(), 2);
@@ -200,15 +200,18 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, Axes};
     ///
-    /// let a = Matrix::<f64>::new(2,2, vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = a.mean(Axes::Row);
-    /// assert_eq!(*c.data(), vec![2.0, 3.0]);
+    /// assert_eq!(c, vector![2.0, 3.0]);
     ///
     /// let d = a.mean(Axes::Col);
-    /// assert_eq!(*d.data(), vec![1.5, 3.5]);
+    /// assert_eq!(d, vector![1.5, 3.5]);
+    /// # }
     /// ```
     pub fn mean(&self, axis: Axes) -> Vector<T> {
         if self.data.len() == 0 {
@@ -239,15 +242,18 @@ impl<T: Float + FromPrimitive> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::{Matrix, Axes};
     ///
-    /// let a = Matrix::<f32>::new(2,2,vec![1.0,2.0,3.0,4.0]);
+    /// let a = matrix![1.0, 2.0;
+    ///                 3.0, 4.0];
     ///
     /// let c = a.variance(Axes::Row).unwrap();
-    /// assert_eq!(*c.data(), vec![2.0, 2.0]);
+    /// assert_eq!(c, vector![2.0, 2.0]);
     ///
     /// let d = a.variance(Axes::Col).unwrap();
-    /// assert_eq!(*d.data(), vec![0.5, 0.5]);
+    /// assert_eq!(d, vector![0.5, 0.5]);
+    /// # }
     /// ```
     ///
     /// # Failures
@@ -311,15 +317,18 @@ impl<T: Any + Float> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Matrix::new(2,2, vec![2.0,3.0,1.0,2.0]);
-    /// let y = Vector::new(vec![13.0,8.0]);
+    /// let a = matrix![2.0, 3.0;
+    ///                 1.0, 2.0];
+    /// let y = vector![13.0, 8.0];
     ///
     /// let x = a.solve(y).unwrap();
     ///
-    /// assert_eq!(*x.data(), vec![2.0, 3.0]);
+    /// assert_eq!(x, vector![2.0, 3.0]);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -343,14 +352,17 @@ impl<T: Any + Float> Matrix<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::matrix::Matrix;
     ///
-    /// let a = Matrix::new(2,2, vec![2.,3.,1.,2.]);
+    /// let a = matrix![2., 3.;
+    ///                 1., 2.];
     /// let inv = a.clone().inverse().expect("This matrix should have an inverse!");
     ///
     /// let I = a * inv;
     ///
-    /// assert_eq!(*I.data(), vec![1.0,0.0,0.0,1.0]);
+    /// assert_eq!(I, matrix![1.0, 0.0; 0.0, 1.0]);
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -406,14 +418,13 @@ impl<T: Any + Float> Matrix<T> {
     /// # Examples
     ///
     /// ```
-    /// use rulinalg::matrix::Matrix;
-    ///
-    /// let a = Matrix::new(3,3, vec![1.0,2.0,0.0,
-    ///                               0.0,3.0,4.0,
-    ///                               5.0, 1.0, 2.0]);
+    /// # #[macro_use] extern crate rulinalg; fn main() {
+    /// let a = matrix![1.0, 2.0, 0.0;
+    ///                 0.0, 3.0, 4.0;
+    ///                 5.0, 1.0, 2.0];
     ///
     /// let det = a.det();
-    ///
+    /// # }
     /// ```
     ///
     /// # Panics

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,8 +12,8 @@ use std::ops::{Add, Mul, Sub, Div};
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
-/// let b = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
+/// let b = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::dot(&a,&b);
 /// ```
@@ -164,12 +164,12 @@ pub fn vec_bin_op<F, T>(u: &[T], v: &[T], f: F) -> Vec<T>
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
-/// let b = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
+/// let b = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::vec_sum(&a,&b);
 ///
-/// assert_eq!(c, vec![2.0,4.0, 6.0, 8.0]);
+/// assert_eq!(c, vec![2.0, 4.0, 6.0, 8.0]);
 /// ```
 pub fn vec_sum<T: Copy + Add<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
     vec_bin_op(u, v, |x, y| x + y)
@@ -182,8 +182,8 @@ pub fn vec_sum<T: Copy + Add<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
-/// let b = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
+/// let b = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::vec_sub(&a,&b);
 ///
@@ -199,12 +199,12 @@ pub fn vec_sub<T: Copy + Sub<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
-/// let b = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
+/// let b = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::ele_mul(&a,&b);
 ///
-/// assert_eq!(c, vec![1.0,4.0,9.0,16.0]);
+/// assert_eq!(c, vec![1.0, 4.0, 9.0, 16.0]);
 /// ```
 pub fn ele_mul<T: Copy + Mul<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
     vec_bin_op(u, v, |x, y| x * y)
@@ -216,8 +216,8 @@ pub fn ele_mul<T: Copy + Mul<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
-/// let b = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
+/// let b = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::ele_div(&a,&b);
 ///
@@ -236,7 +236,7 @@ pub fn ele_div<T: Copy + Div<T, Output = T>>(u: &[T], v: &[T]) -> Vec<T> {
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::argmax(&a);
 /// assert_eq!(c.0, 3);
@@ -268,7 +268,7 @@ pub fn argmax<T>(u: &[T]) -> (usize, T)
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![5.0,2.0,3.0,4.0];
+/// let a = vec![5.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::argmin(&a);
 /// assert_eq!(c.0, 1);
@@ -300,7 +300,7 @@ pub fn argmin<T>(u: &[T]) -> (usize, T)
 ///
 /// ```
 /// use rulinalg::utils;
-/// let a = vec![1.0,2.0,3.0,4.0];
+/// let a = vec![1.0, 2.0, 3.0, 4.0];
 ///
 /// let c = utils::find(&a, 3.0);
 /// assert_eq!(c, 2);

--- a/src/vector/impl_vec.rs
+++ b/src/vector/impl_vec.rs
@@ -307,7 +307,7 @@ impl<T: Copy + Zero + Mul<T, Output = T> + Add<T, Output = T>> Vector<T> {
     /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = vector![1.0,2.0,3.0,4.0];
+    /// let a = vector![1.0, 2.0, 3.0, 4.0];
     /// let b = vector![2.0; 4];
     ///
     /// let c = a.dot(&b);
@@ -330,7 +330,7 @@ impl<T: Copy + Zero + Add<T, Output = T>> Vector<T> {
     /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = vector![1.0,2.0,3.0,4.0];
+    /// let a = vector![1.0, 2.0, 3.0, 4.0];
     ///
     /// let c = a.sum();
     /// assert_eq!(c, 10.0);
@@ -372,8 +372,8 @@ impl<T: Copy + Div<T, Output = T>> Vector<T> {
     /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = vector![1.0,2.0,3.0,4.0];
-    /// let b = vector![1.0,2.0,3.0,4.0];
+    /// let a = vector![1.0, 2.0, 3.0, 4.0];
+    /// let b = vector![1.0, 2.0, 3.0, 4.0];
     ///
     /// let c = &a.elediv(&b);
     /// assert_eq!(c, &vector![1.0; 4]);

--- a/src/vector/impl_vec.rs
+++ b/src/vector/impl_vec.rs
@@ -39,10 +39,12 @@ impl<T> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
     /// let v = Vector::from_fn(4, |x| x * 3);
-    /// assert_eq!(v, Vector::new(vec![0, 3, 6, 9]));
+    /// assert_eq!(v, vector![0, 3, 6, 9]);
+    /// # }
     /// ```
     pub fn from_fn<F>(size: usize, mut f: F) -> Vector<T>
         where F: FnMut(usize) -> T {
@@ -167,16 +169,18 @@ impl<T: Copy> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     /// fn add_two(a: f64) -> f64 {
     ///     a + 2f64
     /// }
     ///
-    /// let a = Vector::new(vec![0.;4]);
+    /// let a = vector![0.; 4];
     ///
     /// let b = a.apply(&add_two);
     ///
-    /// assert_eq!(b.into_vec(), vec![2.0; 4]);
+    /// assert_eq!(b, vector![2.0; 4]);
+    /// # }
     /// ```
     pub fn apply(mut self, f: &Fn(T) -> T) -> Vector<T> {
         for val in &mut self.data {
@@ -194,12 +198,14 @@ impl<T: Copy + PartialOrd> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,0.0,5.0]);
+    /// let a = vector![1.0,2.0,0.0,5.0];
     /// let b = a.argmax();
     /// assert_eq!(b.0, 3);
     /// assert_eq!(b.1, 5.0);
+    /// # }
     /// ```
     pub fn argmax(&self) -> (usize, T) {
         utils::argmax(&self.data)
@@ -212,12 +218,14 @@ impl<T: Copy + PartialOrd> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,0.0,5.0]);
+    /// let a = vector![1.0, 2.0, 0.0, 5.0];
     /// let b = a.argmin();
     /// assert_eq!(b.0, 2);
     /// assert_eq!(b.1, 0.0);
+    /// # }
     /// ```
     pub fn argmin(&self) -> (usize, T) {
         utils::argmin(&self.data)
@@ -228,14 +236,16 @@ impl<T: Copy + PartialOrd> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,3.0,4.0,5.0]);
+    /// let a = vector![1.0, 2.0, 3.0, 4.0, 5.0];
     ///
-    /// let a_lower = a.select(&[2,3,4]);
+    /// let a_lower = a.select(&[2, 3, 4]);
     ///
     /// // Prints [3,4,5]
-    /// println!("{:?}", a_lower.data());
+    /// assert_eq!(a_lower, vector![3.0, 4.0, 5.0]);
+    /// # }
     /// ```
     pub fn select(&self, idxs: &[usize]) -> Vector<T> {
         let mut new_data = Vec::with_capacity(idxs.len());
@@ -294,13 +304,15 @@ impl<T: Copy + Zero + Mul<T, Output = T> + Add<T, Output = T>> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,3.0,4.0]);
-    /// let b = Vector::new(vec![2.0; 4]);
+    /// let a = vector![1.0,2.0,3.0,4.0];
+    /// let b = vector![2.0; 4];
     ///
     /// let c = a.dot(&b);
     /// assert_eq!(c, 20.0);
+    /// # }
     /// ```
     pub fn dot(&self, v: &Vector<T>) -> T {
         utils::dot(&self.data, &v.data)
@@ -315,12 +327,14 @@ impl<T: Copy + Zero + Add<T, Output = T>> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,3.0,4.0]);
+    /// let a = vector![1.0,2.0,3.0,4.0];
     ///
     /// let c = a.sum();
     /// assert_eq!(c, 10.0);
+    /// # }
     /// ```
     pub fn sum(&self) -> T {
         utils::unrolled_sum(&self.data[..])
@@ -333,13 +347,15 @@ impl<T: Copy + Mul<T, Output = T>> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,3.0,4.0]);
-    /// let b = Vector::new(vec![1.0,2.0,3.0,4.0]);
+    /// let a = vector![1.0, 2.0, 3.0, 4.0];
+    /// let b = vector![1.0, 2.0, 3.0, 4.0];
     ///
     /// let c = &a.elemul(&b);
-    /// assert_eq!(*c.data(), vec![1.0, 4.0, 9.0, 16.0]);
+    /// assert_eq!(c, &vector![1.0, 4.0, 9.0, 16.0]);
+    /// # }
     /// ```
     pub fn elemul(&self, v: &Vector<T>) -> Vector<T> {
         assert_eq!(self.size, v.size);
@@ -353,13 +369,15 @@ impl<T: Copy + Div<T, Output = T>> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::new(vec![1.0,2.0,3.0,4.0]);
-    /// let b = Vector::new(vec![1.0,2.0,3.0,4.0]);
+    /// let a = vector![1.0,2.0,3.0,4.0];
+    /// let b = vector![1.0,2.0,3.0,4.0];
     ///
     /// let c = &a.elediv(&b);
-    /// assert_eq!(*c.data(), vec![1.0; 4]);
+    /// assert_eq!(c, &vector![1.0; 4]);
+    /// # }
     /// ```
     pub fn elediv(&self, v: &Vector<T>) -> Vector<T> {
         assert_eq!(self.size, v.size);
@@ -373,13 +391,15 @@ impl<T: Float> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     /// use rulinalg::norm::Euclidean;
     ///
-    /// let a = Vector::new(vec![3.0,4.0]);
+    /// let a = vector![3.0, 4.0];
     /// let c = a.norm(Euclidean);
     ///
     /// assert_eq!(c, 5.0);
+    /// # }
     /// ```
     pub fn norm<N: VectorNorm<T>>(&self, norm: N) -> T {
         norm.norm(self)
@@ -390,16 +410,18 @@ impl<T: Float> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     /// use rulinalg::norm::Euclidean;
     ///
-    /// let a = Vector::new(vec![3.0, 4.0]);
-    /// let b = Vector::new(vec![0.0, 8.0]);
+    /// let a = vector![3.0, 4.0];
+    /// let b = vector![0.0, 8.0];
     ///
     /// // Compute the square root of the sum of
     /// // elementwise squared-differences
     /// let c = a.metric(&b, Euclidean);
     /// assert_eq!(c, 5.0);
+    /// # }
     /// ```
     pub fn metric<M: VectorMetric<T>>(&self, v: &Vector<T>, m: M) -> T {
         m.metric(self, v)
@@ -414,12 +436,14 @@ impl<T: Float + FromPrimitive> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::<f32>::new(vec![1.0,2.0,3.0,4.0]);
+    /// let a = vector![1.0, 2.0, 3.0, 4.0];
     ///
     /// let c = a.mean();
     /// assert_eq!(c, 2.5);
+    /// # }
     /// ```
     pub fn mean(&self) -> T {
         let sum = self.sum();
@@ -433,12 +457,14 @@ impl<T: Float + FromPrimitive> Vector<T> {
     /// # Examples
     ///
     /// ```
+    /// # #[macro_use] extern crate rulinalg; fn main() {
     /// use rulinalg::vector::Vector;
     ///
-    /// let a = Vector::<f32>::new(vec![1.0,2.0,3.0,4.0]);
+    /// let a = vector![1.0, 2.0, 3.0, 4.0];
     ///
     /// let c = a.variance();
-    /// assert_eq!(c, 5.0/3.0);
+    /// assert_eq!(c, 5.0 / 3.0);
+    /// # }
     /// ```
     pub fn variance(&self) -> T {
         let m = self.mean();


### PR DESCRIPTION
Use ``matrix`` and ``vector`` macros in API docs.