### PR TITLE
LU rewrite, second draft

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -10,4 +10,5 @@ mod linalg {
 	mod matrix;
 	mod svd;
 	mod norm;
+	mod permutation;
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -5,10 +5,11 @@ extern crate num as libnum;
 extern crate test;
 extern crate rand;
 
-mod linalg {
+pub mod linalg {
 	mod iter;
 	mod matrix;
 	mod svd;
 	mod norm;
 	mod permutation;
+	pub mod util;
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -9,6 +9,7 @@ pub mod linalg {
 	mod iter;
 	mod matrix;
 	mod svd;
+	mod lu;
 	mod norm;
 	mod permutation;
 	pub mod util;

--- a/benches/linalg/lu.rs
+++ b/benches/linalg/lu.rs
@@ -1,0 +1,140 @@
+use rulinalg::matrix::{BaseMatrix, BaseMatrixMut,
+                       Matrix};
+use rulinalg::matrix::decomposition::{PartialPivLu};
+use rulinalg::vector::Vector;
+
+use linalg::util::reproducible_random_matrix;
+use libnum::{Zero, One};
+
+use test::Bencher;
+
+fn nullify_upper_triangular_part<T: Zero>(matrix: &mut Matrix<T>) {
+    for i in 0 .. matrix.rows() {
+        for j in (i + 1) .. matrix.cols() {
+            matrix[[i, j]] = T::zero();
+        }
+    }
+
+    // TODO: assert is_lower_triangular
+}
+
+fn nullify_lower_triangular_part<T: Zero>(matrix: &mut Matrix<T>) {
+    for i in 0 .. matrix.rows() {
+        for j in 0 .. i {
+            matrix[[i, j]] = T::zero();
+        }
+    }
+
+    // TODO: assert is_upper_triangular
+}
+
+fn set_diagonal_to_one<T: One>(matrix: &mut Matrix<T>) {
+    use rulinalg::matrix::DiagOffset::Main;
+    for d in matrix.diag_iter_mut(Main) {
+        *d = T::one();
+    }
+}
+
+fn well_conditioned_matrix(n: usize) -> Matrix<f64> {
+    let mut l = reproducible_random_matrix(n, n);
+    let mut u = reproducible_random_matrix(n, n);
+    nullify_upper_triangular_part(&mut l);
+    nullify_lower_triangular_part(&mut u);
+    // By making the diagonal of both L and U consist
+    // exclusively of 1, the eigenvalues of the resulting
+    // matrix LU will also have eigenvalues of 1
+    // (and thus be well-conditioned)
+    set_diagonal_to_one(&mut l);
+    set_diagonal_to_one(&mut u);
+    return l * u;
+}
+
+#[bench]
+fn partial_piv_lu_decompose_10x10(b: &mut Bencher) {
+    let n = 10;
+    let x = well_conditioned_matrix(n);
+    b.iter(|| {
+        // Assume that the cost of cloning x is roughly
+        // negligible in comparison with the cost of LU
+        PartialPivLu::decompose(x.clone()).expect("Matrix is well-conditioned")
+    })
+}
+
+#[bench]
+fn partial_piv_lu_decompose_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = well_conditioned_matrix(n);
+    b.iter(|| {
+        // Assume that the cost of cloning x is roughly
+        // negligible in comparison with the cost of LU
+        PartialPivLu::decompose(x.clone()).expect("Matrix is well-conditioned")
+    })
+}
+
+#[bench]
+fn partial_piv_lu_inverse_10x10(b: &mut Bencher) {
+    let n = 10;
+    let x = well_conditioned_matrix(n);
+    let lu = PartialPivLu::decompose(x)
+                     .expect("Matrix is well-conditioned.");
+    b.iter(|| {
+        lu.inverse()
+    })
+}
+
+#[bench]
+fn partial_piv_lu_inverse_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = well_conditioned_matrix(n);
+    let lu = PartialPivLu::decompose(x)
+                     .expect("Matrix is well-conditioned.");
+    b.iter(|| {
+        lu.inverse()
+    })
+}
+
+#[bench]
+fn partial_piv_lu_det_10x10(b: &mut Bencher) {
+    let n = 10;
+    let x = well_conditioned_matrix(n);
+    let lu = PartialPivLu::decompose(x)
+                     .expect("Matrix is well-conditioned.");
+    b.iter(|| {
+        lu.det()
+    })
+}
+
+#[bench]
+fn partial_piv_lu_det_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = well_conditioned_matrix(n);
+    let lu = PartialPivLu::decompose(x)
+                     .expect("Matrix is well-conditioned.");
+    b.iter(|| {
+        lu.det()
+    })
+}
+
+#[bench]
+fn partial_piv_lu_solve_10x10(b: &mut Bencher) {
+    let n = 10;
+    let x = well_conditioned_matrix(n);
+    let lu = PartialPivLu::decompose(x)
+                     .expect("Matrix is well-conditioned.");
+    b.iter(|| {
+        let b = Vector::ones(n);
+        lu.solve(b).unwrap()
+    })
+}
+
+#[bench]
+fn partial_piv_lu_solve_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = well_conditioned_matrix(n);
+    let lu = PartialPivLu::decompose(x)
+                     .expect("Matrix is well-conditioned.");
+    b.iter(|| {
+        let b = Vector::ones(n);
+        lu.solve(b).unwrap()
+    })
+}

--- a/benches/linalg/permutation.rs
+++ b/benches/linalg/permutation.rs
@@ -1,0 +1,85 @@
+use rulinalg::matrix::PermutationMatrix;
+use rulinalg::vector::Vector;
+
+use test::Bencher;
+
+/// A perfect shuffle as defined at
+/// https://en.wikipedia.org/wiki/Faro_shuffle
+/// Note that it creates a permutation matrix of size
+/// 2 * n and not n.
+fn perfect_shuffle<T>(n: usize) -> PermutationMatrix<T> {
+    let array = (0 .. 2 * n).map(|k|
+            if (k + 1) % 2 == 0 {
+                n + (k + 1) / 2 - 1
+            } else {
+                (k + 1) / 2
+            }
+        ).collect::<Vec<_>>();
+    PermutationMatrix::from_array(array).unwrap()
+}
+
+#[bench]
+fn identity_permutation_mul_vector_100(b: &mut Bencher) {
+    let n = 100;
+    let p = PermutationMatrix::identity(n);
+    let x: Vector<f64> = Vector::zeros(n);
+
+    b.iter(|| {
+        &p * &x
+    })
+}
+
+#[bench]
+fn identity_permutation_as_matrix_mul_vector_100(b: &mut Bencher) {
+    let n = 100;
+    let p = PermutationMatrix::identity(n).as_matrix();
+    let x: Vector<f64> = Vector::zeros(n);
+
+    b.iter(|| {
+        &p * &x
+    })
+}
+
+#[bench]
+fn identity_permutation_mul_vector_1000(b: &mut Bencher) {
+    let n = 1000;
+    let p = PermutationMatrix::identity(n);
+    let x: Vector<f64> = Vector::zeros(n);
+
+    b.iter(|| {
+        &p * &x
+    })
+}
+
+#[bench]
+fn identity_permutation_as_matrix_mul_vector_1000(b: &mut Bencher) {
+    let n = 1000;
+    let p = PermutationMatrix::identity(n).as_matrix();
+    let x: Vector<f64> = Vector::zeros(n);
+
+    b.iter(|| {
+        &p * &x
+    })
+}
+
+#[bench]
+fn perfect_shuffle_permutation_mul_vector_1000(b: &mut Bencher) {
+    let n = 1000;
+    let p = perfect_shuffle(500);
+    let x: Vector<f64> = Vector::zeros(n);
+
+    b.iter(|| {
+        &p * &x
+    })
+}
+
+#[bench]
+fn perfect_shuffle_permutation_as_matrix_mul_vector_1000(b: &mut Bencher) {
+    let n = 1000;
+    let p = perfect_shuffle(500).as_matrix();
+    let x: Vector<f64> = Vector::zeros(n);
+
+    b.iter(|| {
+        &p * &x
+    })
+}

--- a/benches/linalg/svd.rs
+++ b/benches/linalg/svd.rs
@@ -1,14 +1,5 @@
 use test::Bencher;
-use rand;
-use rand::{Rng, SeedableRng};
-use rulinalg::matrix::Matrix;
-
-fn reproducible_random_matrix(rows: usize, cols: usize) -> Matrix<f64> {
-    const STANDARD_SEED: [usize; 4] = [12, 2049, 4000, 33];
-    let mut rng = rand::StdRng::from_seed(&STANDARD_SEED);
-    let elements: Vec<_> = rng.gen_iter::<f64>().take(rows * cols).collect();
-    Matrix::new(rows, cols, elements)
-}
+use linalg::util::reproducible_random_matrix;
 
 #[bench]
 fn svd_10_10(b: &mut Bencher) {

--- a/benches/linalg/util.rs
+++ b/benches/linalg/util.rs
@@ -1,0 +1,10 @@
+use rulinalg::matrix::Matrix;
+use rand;
+use rand::{Rng, SeedableRng};
+
+pub fn reproducible_random_matrix(rows: usize, cols: usize) -> Matrix<f64> {
+    const STANDARD_SEED: [usize; 4] = [12, 2049, 4000, 33];
+    let mut rng = rand::StdRng::from_seed(&STANDARD_SEED);
+    let elements: Vec<_> = rng.gen_iter::<f64>().take(rows * cols).collect();
+    Matrix::new(rows, cols, elements)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ pub mod vector;
 pub mod ulp;
 pub mod norm;
 
+mod testsupport;
+
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub mod vector;
 pub mod ulp;
 pub mod norm;
 
+#[cfg(test)]
 mod testsupport;
 
 #[cfg(test)]

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -196,6 +196,8 @@ impl<T: 'static + Float> PartialPivLu<T> {
     }
 }
 
+// TODO: Remove Any bound (cannot for the time being, since
+// back substitution uses Any bound)
 impl<T> PartialPivLu<T> where T: Any + Float {
     /// Solves the linear system `Ax = b`.
     ///

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -162,12 +162,15 @@ fn lu_forward_substitution<T: Float>(lu: &Matrix<T>, b: Vector<T>) -> Vector<T> 
     let mut x = b;
 
     for (i, row) in lu.row_iter().enumerate().skip(1) {
-        let adjustment = row.iter()
+        // Note that at time of writing we need raw_slice here for
+        // auto-vectorization to kick in
+        let adjustment = row.raw_slice()
+                            .iter()
                             .take(i)
                             .cloned()
                             .zip(x.iter().cloned())
-                            .map(|(l_coeff, x_coeff)| l_coeff * x_coeff)
-                            .fold(T::zero(), |a, b| a + b);
+                            .fold(T::zero(), |sum, (l, x)| sum + l * x);
+
         x[i] = x[i] - adjustment;
     }
     x

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -363,6 +363,10 @@ impl<T> Matrix<T> where T: Any + Float
     ///
     /// Returns L,U, and P respectively.
     ///
+    /// This function is deprecated.
+    /// Please see [PartialPivLu](decomposition/struct.PartialPivLu.html)
+    /// for a replacement.
+    ///
     /// # Examples
     ///
     /// ```
@@ -384,6 +388,7 @@ impl<T> Matrix<T> where T: Any + Float
     /// # Failures
     ///
     /// - Matrix cannot be LUP decomposed.
+    #[deprecated]
     pub fn lup_decomp(self) -> Result<(Matrix<T>, Matrix<T>, Matrix<T>), Error> {
         let n = self.cols;
         assert!(self.rows == n, "Matrix must be square for LUP decomposition.");

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -433,7 +433,7 @@ impl<T> Matrix<T> where T: Any + Float
 
 #[cfg(test)]
 mod tests {
-    use matrix::{Matrix, BaseMatrix, PermutationMatrix};
+    use matrix::{Matrix, PermutationMatrix};
     use testsupport::{is_lower_triangular, is_upper_triangular};
 
     use super::{PartialPivLu, LUP};
@@ -441,6 +441,7 @@ mod tests {
 
     use libnum::Float;
 
+    #[allow(deprecated)]
     #[test]
     #[should_panic]
     fn test_non_square_lup_decomp() {
@@ -449,6 +450,7 @@ mod tests {
         let _ = a.lup_decomp();
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_lup_decomp() {
         use error::ErrorKind;

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -116,18 +116,27 @@ impl<T> PartialPivLu<T> where T: Any + Float {
         // AX = I,
         // where X is the inverse of A, and I is the identity
         // matrix of appropriate dimension.
+        //
+        // Note that this is not optimal in terms of performance,
+        // and there is likely significant potential for improvement.
+        //
+        // A more performant technique is usually to compute the
+        // triangular inverse of each of the L and U triangular matrices,
+        // but this again requires efficient algorithms (blocked/recursive)
+        // to invert triangular matrices, which at this point
+        // we do not have available.
 
         // Solve for each column of the inverse matrix
         for i in 0 .. n {
             e[i] = T::one();
 
-            let y = try!(self.solve(e));
+            let col = try!(self.solve(e));
 
             for j in 0 .. n {
-                inv[[j, i]] = y[j];
+                inv[[j, i]] = col[j];
             }
 
-            e = Vector::zeros(n);
+            e = col.apply(&|_| T::zero());
         }
 
         Ok(inv)

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -10,13 +10,18 @@ use libnum::Float;
 use matrix::decomposition::Decomposition;
 
 /// TODO: docs
+#[derive(Debug, Clone)]
 pub struct LUP<T> {
+    /// The lower triangular matrix in the decomposition.
     pub l: Matrix<T>,
+    /// The upper triangular matrix in the decomposition.
     pub u: Matrix<T>,
+    /// The permutation matrix in the decomposition.
     pub p: Matrix<T>
 }
 
 /// TODO: Docs
+#[derive(Debug, Clone)]
 pub struct PartialPivLu<T> {
     // For now, we store the full matrices, but
     // we can improve this by storing the decomposition
@@ -35,7 +40,7 @@ impl<T> Decomposition for PartialPivLu<T> {
 
 impl<T: 'static + Float> PartialPivLu<T> {
     /// TODO
-    fn decompose(matrix: Matrix<T>) -> Result<Self, Error> {
+    pub fn decompose(matrix: Matrix<T>) -> Result<Self, Error> {
         matrix.lup_decomp().map(|(l, u, p)|
             PartialPivLu {
                 lup: LUP {

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -149,11 +149,11 @@ impl<T: Clone + One + Zero> Decomposition for PartialPivLu<T> {
 impl<T: 'static + Float> PartialPivLu<T> {
     /// Performs the decomposition.
     ///
-    /// ### Panics
+    /// # Panics
     ///
     /// The matrix must be square.
     ///
-    /// ### Errors
+    /// # Errors
     ///
     /// An error will be returned if the matrix
     /// is singular to working precision (badly conditioned).
@@ -206,16 +206,16 @@ impl<T> PartialPivLu<T> where T: Any + Float {
     /// well suited to solving multiple such linear systems
     /// involving the same `A` but different `b`.
     ///
-    /// #### Errors
+    /// # Errors
     ///
     /// If the matrix is very ill-conditioned, the function
     /// might fail to obtain the solution to the system.
     ///
-    /// ### Panics
+    /// # Panics
     ///
     /// The right-hand side vector `b` must have compatible size.
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```
     /// # #[macro_use] extern crate rulinalg;
@@ -248,7 +248,7 @@ impl<T> PartialPivLu<T> where T: Any + Float {
     /// Computes the inverse of the matrix which this LUP decomposition
     /// represents.
     ///
-    /// ### Errors
+    /// # Errors
     /// The inversion might fail if the matrix is very ill-conditioned.
     pub fn inverse(&self) -> Result<Matrix<T>, Error> {
         let n = self.lu.rows();

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -175,8 +175,8 @@ impl<T: 'static + Float> PartialPivLu<T> {
             }
             if curr_max.abs() < T::epsilon() {
                 return Err(Error::new(ErrorKind::DivByZero,
-                    "Singular matrix found in LUP decomposition. \
-                    A value in the diagonal of U == 0.0."));
+                    "The matrix is too ill-conditioned for
+                     LU decomposition with partial pivoting."));
             }
 
             lu.swap_rows(index, curr_max_idx);

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -28,6 +28,19 @@ use error::{Error, ErrorKind};
 
 use libnum::{Float};
 
+/// Base trait for decompositions.
+///
+/// A matrix decomposition, or factorization,
+/// is a procedure which takes a matrix `X` and returns
+/// a set of `k` factors `X_1, X_2, ..., X_k` such that
+/// `X = X_1 * X_2 * ... * X_k`.
+pub trait Decomposition {
+    type Factors;
+
+    /// Extract the individual factors from this decomposition.
+    fn unpack(self) -> Self::Factors;
+}
+
 impl<T> Matrix<T>
     where T: Any + Float
 {

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -1,14 +1,97 @@
-//! Matrix Decompositions
+//! Decompositions for matrices.
 //!
-//! References:
-//! 1. [On Matrix Balancing and EigenVector computation]
-//! (http://arxiv.org/pdf/1401.5766v1.pdf), James, Langou and Lowery
+//! This module houses the decomposition API of `rulinalg`.
+//! A decomposition - or factorization - of a matrix is an
+//! ordered set of *factors* such that when multiplied reconstructs
+//! the original matrix. The [Decomposition](trait.Decomposition.html)
+//! trait encodes this property.
 //!
-//! 2. [The QR algorithm for eigen decomposition]
-//! (http://people.inf.ethz.ch/arbenz/ewp/Lnotes/chapter4.pdf)
+//! # The decomposition API
 //!
-//! 3. [Computation of the SVD]
-//! (http://www.cs.utexas.edu/users/inderjit/public_papers/HLA_SVD.pdf)
+//! Decompositions in `rulinalg` are in general modeled after
+//! the following:
+//!
+//! 1. Given an appropriate matrix, an opaque decomposition object
+//!    may be computed which internally stores the factors
+//!    in an efficient and appropriate format.
+//! 2. In general, the factors may not be immediately available
+//!    as distinct matrices after decomposition. If the user
+//!    desires the explicit matrix factors involved in the
+//!    decomposition, the user must `unpack` the decomposition.
+//! 3. Before unpacking the decomposition, the decomposition
+//!    data structure in question may offer an API that provides
+//!    efficient implementations for some of the most common
+//!    applications of the decomposition. The user is encouraged
+//!    to use the decomposition-specific API rather than unpacking
+//!    the decompositions whenever possible.
+//!
+//! For a motivating example that explains the rationale behind
+//! this design, let us consider the typical LU decomposition with
+//! partial pivoting. In this case, given a square invertible matrix
+//! `A`, one may find matrices `P`, `L` and `U` such that
+//! `PA = LU`. Here `P` is a permutation matrix, `L` is a lower
+//! triangular matrix and `U` is an upper triangular matrix.
+//!
+//! Once the decomposition has been obtained, one of its applications
+//! is the efficient solution of multiple similar linear systems.
+//! Consider that while computing the LU decomposition requires
+//! O(n<sup>3</sup>) floating point operations, the solution to
+//! the system `Ax = b` can be computed in O(n<sup>2</sup>) floating
+//! point operations if the LU decomposition has already been obtained.
+//! Since the right-hand side `b` has no bearing on the LU decomposition,
+//! it follows that one can efficiently solve any such system for any `b`.
+//!
+//! It turns out that the matrices `L` and `U` can be stored compact
+//! in the space of a single matrix. Indeed, this is how `PartialPivLu`
+//! stores the LU decomposition internally. This allows `rulinalg` to
+//! provide the user with efficient implementations of common applications
+//! for the LU decomposition. However, the full matrix factors are easily
+//! available to the user by unpacking the decomposition.
+//!
+//! # Available decompositions
+//!
+//! **The decompositions API is a work in progress.**
+//!
+//! Currently, only a portion of the available decompositions in `rulinalg`
+//! are available through the decomposition API. Please see the
+//! [Matrix](../struct.Matrix.html) API for the old decomposition
+//! implementations that have yet not been implemented within
+//! this framework.
+//!
+//! <table>
+//! <thead>
+//! <tr>
+//! <th>Decomposition</th>
+//! <th>Applicable to</th>
+//! <th>Supported features</th>
+//! </tr>
+//! <tbody>
+//!
+//! <tr>
+//! <td><a href="struct.PartialPivLu.html">PartialPivLu</a></td>
+//! <td>Square, invertible matrices</td>
+//! <td>
+//!     <ul>
+//!     <li>Linear system solving</li>
+//!     <li>Matrix inverse</li>
+//!     <li>Determinant computation</li>
+//!     </ul>
+//! </td>
+//! </tr>
+//!
+//! </tbody>
+//! </table>
+
+// References:
+//
+// 1. [On Matrix Balancing and EigenVector computation]
+// (http://arxiv.org/pdf/1401.5766v1.pdf), James, Langou and Lowery
+//
+// 2. [The QR algorithm for eigen decomposition]
+// (http://people.inf.ethz.ch/arbenz/ewp/Lnotes/chapter4.pdf)
+//
+// 3. [Computation of the SVD]
+// (http://www.cs.utexas.edu/users/inderjit/public_papers/HLA_SVD.pdf)
 
 mod qr;
 mod cholesky;

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -39,7 +39,7 @@
 //! the system `Ax = b` can be computed in O(n<sup>2</sup>) floating
 //! point operations if the LU decomposition has already been obtained.
 //! Since the right-hand side `b` has no bearing on the LU decomposition,
-//! it follows that one can efficiently solve any such system for any `b`.
+//! it follows that one can efficiently solve this system for any `b`.
 //!
 //! It turns out that the matrices `L` and `U` can be stored compactly
 //! in the space of a single matrix. Indeed, this is how `PartialPivLu`

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -41,7 +41,7 @@
 //! Since the right-hand side `b` has no bearing on the LU decomposition,
 //! it follows that one can efficiently solve any such system for any `b`.
 //!
-//! It turns out that the matrices `L` and `U` can be stored compact
+//! It turns out that the matrices `L` and `U` can be stored compactly
 //! in the space of a single matrix. Indeed, this is how `PartialPivLu`
 //! stores the LU decomposition internally. This allows `rulinalg` to
 //! provide the user with efficient implementations of common applications

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -26,6 +26,8 @@ use vector::Vector;
 use utils;
 use error::{Error, ErrorKind};
 
+pub use self::lu::{PartialPivLu, LUP};
+
 use libnum::{Float};
 
 /// Base trait for decompositions.
@@ -35,6 +37,9 @@ use libnum::{Float};
 /// a set of `k` factors `X_1, X_2, ..., X_k` such that
 /// `X = X_1 * X_2 * ... * X_k`.
 pub trait Decomposition {
+    /// The type representing the collection of factors
+    /// of which the product is equivalent to the
+    /// decomposed matrix.
     type Factors;
 
     /// Extract the individual factors from this decomposition.

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -120,9 +120,8 @@ use libnum::{Float};
 /// a set of `k` factors `X_1, X_2, ..., X_k` such that
 /// `X = X_1 * X_2 * ... * X_k`.
 pub trait Decomposition {
-    /// The type representing the collection of factors
-    /// of which the product is equivalent to the
-    /// decomposed matrix.
+    /// The type representing the ordered set of factors
+    /// that when multiplied yields the decomposed matrix.
     type Factors;
 
     /// Extract the individual factors from this decomposition.

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -15,7 +15,7 @@ use error::{Error, ErrorKind};
 use utils;
 use vector::Vector;
 
-mod decomposition;
+pub mod decomposition;
 mod impl_ops;
 mod impl_mat;
 mod mat_mul;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -12,7 +12,6 @@ use std::marker::PhantomData;
 use libnum::Float;
 
 use error::{Error, ErrorKind};
-use utils;
 use vector::Vector;
 
 pub mod decomposition;
@@ -350,35 +349,4 @@ fn forward_substitution<T, M>(m: &M, y: Vector<T>) -> Result<Vector<T>, Error>
     }
 
     Ok(Vector::new(x))
-}
-
-/// Computes the parity of a permutation matrix.
-fn parity<T, M>(m: &M) -> T
-    where T: Any + Float,
-          M: BaseMatrix<T>
-{
-    let mut visited = vec![false; m.rows()];
-    let mut sgn = T::one();
-
-    for k in 0..m.rows() {
-        if !visited[k] {
-            let mut next = k;
-            let mut len = 0;
-
-            while !visited[next] {
-                len += 1;
-                visited[next] = true;
-                unsafe {
-                    next = utils::find(&m.row_unchecked(next)
-                                           .raw_slice(),
-                                       T::one());
-                }
-            }
-
-            if len % 2 == 0 {
-                sgn = -sgn;
-            }
-        }
-    }
-    sgn
 }

--- a/src/testsupport/constraints.rs
+++ b/src/testsupport/constraints.rs
@@ -1,0 +1,141 @@
+use matrix::BaseMatrix;
+
+use libnum::Zero;
+
+use std::iter::Iterator;
+
+/// Returns true if the matrix is lower triangular, otherwise false.
+/// This generalizes to rectangular matrices, in which case
+/// it returns true if the matrix is lower trapezoidal.
+#[allow(dead_code)]
+pub fn is_lower_triangular<T, M>(m: &M) -> bool
+    where T: Zero + PartialEq<T>, M: BaseMatrix<T> {
+
+    m.row_iter()
+     .enumerate()
+     .all(|(i, row)| row.iter()
+                        .skip(i + 1)
+                        .all(|x| x == &T::zero()))
+}
+
+/// Returns true if the matrix is upper triangular, otherwise false.
+/// This generalizes to rectangular matrices, in which case
+/// it returns true if the matrix is upper trapezoidal.
+#[allow(dead_code)]
+pub fn is_upper_triangular<T, M>(m: &M) -> bool
+    where T: Zero + PartialEq<T>, M: BaseMatrix<T> {
+
+    m.row_iter()
+     .enumerate()
+     .all(|(i, row)| row.iter()
+                        .take(i)
+                        .all(|x| x == &T::zero()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_lower_triangular;
+    use super::is_upper_triangular;
+    use matrix::Matrix;
+
+    #[test]
+    fn is_lower_triangular_empty_matrix() {
+        let x: Matrix<u32> = matrix![];
+        assert!(is_lower_triangular(&x));
+    }
+
+    #[test]
+    fn is_lower_triangular_1x1() {
+        let x = matrix![1];
+        assert!(is_lower_triangular(&x));
+    }
+
+    #[test]
+    fn is_lower_triangular_square() {
+        {
+            let x = matrix![3, 0;
+                            4, 5];
+            assert!(is_lower_triangular(&x));
+        }
+
+        {
+            let x = matrix![1, 0, 0;
+                            3, 3, 0;
+                            0, 4, 6];
+            assert!(is_lower_triangular(&x));
+        }
+
+        {
+            // Diagonal is an important special case
+            let x = matrix![1, 0;
+                            0, 2];
+            assert!(is_lower_triangular(&x));
+        }
+    }
+
+    #[test]
+    fn is_upper_triangular_empty_matrix() {
+        let x: Matrix<u32> = matrix![];
+        assert!(is_upper_triangular(&x));
+    }
+
+    #[test]
+    fn is_upper_triangular_1x1() {
+        let x = matrix![1];
+        assert!(is_upper_triangular(&x));
+    }
+
+    #[test]
+    fn is_upper_triangular_square() {
+        {
+            let x = matrix![3, 4;
+                            0, 5];
+            assert!(is_upper_triangular(&x));
+        }
+
+        {
+            let x = matrix![1, 3, 0;
+                            0, 3, 4;
+                            0, 0, 6];
+            assert!(is_upper_triangular(&x));
+        }
+
+        {
+            // Diagonal is an important special case
+            let x = matrix![1, 0;
+                            0, 2];
+            assert!(is_upper_triangular(&x));
+        }
+    }
+
+    #[test]
+    fn is_upper_triangular_rectangular() {
+        {
+            let x = matrix![1, 2;
+                            0, 3;
+                            0, 0];
+            assert!(is_upper_triangular(&x));
+        }
+
+        {
+            let x = matrix![1, 2, 3;
+                            0, 4, 5];
+            assert!(is_upper_triangular(&x));
+        }
+    }
+
+    quickcheck! {
+        fn property_zero_is_lower_triangular(m: usize, n: usize) -> bool {
+            let x = Matrix::<u32>::zeros(m, n);
+            is_lower_triangular(&x)
+        }
+    }
+
+    quickcheck! {
+        fn property_zero_is_upper_triangular(m: usize, n: usize) -> bool {
+            let x = Matrix::<u32>::zeros(m, n);
+            is_upper_triangular(&x)
+        }
+    }
+}
+

--- a/src/testsupport/constraints.rs
+++ b/src/testsupport/constraints.rs
@@ -7,7 +7,6 @@ use std::iter::Iterator;
 /// Returns true if the matrix is lower triangular, otherwise false.
 /// This generalizes to rectangular matrices, in which case
 /// it returns true if the matrix is lower trapezoidal.
-#[allow(dead_code)]
 pub fn is_lower_triangular<T, M>(m: &M) -> bool
     where T: Zero + PartialEq<T>, M: BaseMatrix<T> {
 
@@ -21,7 +20,6 @@ pub fn is_lower_triangular<T, M>(m: &M) -> bool
 /// Returns true if the matrix is upper triangular, otherwise false.
 /// This generalizes to rectangular matrices, in which case
 /// it returns true if the matrix is upper trapezoidal.
-#[allow(dead_code)]
 pub fn is_upper_triangular<T, M>(m: &M) -> bool
     where T: Zero + PartialEq<T>, M: BaseMatrix<T> {
 

--- a/src/testsupport/mod.rs
+++ b/src/testsupport/mod.rs
@@ -1,0 +1,5 @@
+//! Provides support functions for writing
+//! tests involving data structures provided by rulinalg.
+mod constraints;
+
+pub use self::constraints::{is_lower_triangular, is_upper_triangular};

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -90,6 +90,89 @@ fn matrix_lup_decomp() {
 }
 
 #[test]
+fn matrix_partial_piv_lu() {
+    use rulinalg::matrix::decomposition::{LUP, PartialPivLu};
+    use rulinalg::matrix::decomposition::Decomposition;
+    // This is a port of the test for the old lup_decomp
+    // function, using the new PartialPivLu struct.
+
+    {
+        // Note: this test only works with a _specific_
+        // implementation of LU decomposition, because
+        // an LUP decomposition is not in general unique,
+        // so one cannot test against expected L, U and P
+        // matrices unless one knows exactly which ones the
+        // algorithm works.
+        let a = matrix![1., 3., 5.;
+                        2., 4., 7.;
+                        1., 1., 0.];
+
+        let LUP { l, u, p } = PartialPivLu::decompose(a)
+                                        .expect("Matrix is well-conditioned")
+                                        .unpack();
+
+        let l_true = matrix![1.0,  0.0,  0.0;
+                             0.5,  1.0,  0.0;
+                             0.5, -1.0,  1.0];
+        let u_true = matrix![2.0,  4.0,  7.0;
+                             0.0,  1.0,  1.5;
+                             0.0,  0.0, -2.0];
+        let p_true = matrix![0.0, 1.0, 0.0;
+                            1.0, 0.0, 0.0;
+                            0.0, 0.0, 1.0];
+
+        assert_matrix_eq!(l, l_true, comp = float);
+        assert_matrix_eq!(u, u_true, comp = float);
+        assert_matrix_eq!(p.as_matrix(), p_true, comp = float);
+    }
+
+    {
+        let b = matrix![1., 2., 3., 4., 5.;
+                        3., 0., 4., 5., 6.;
+                        2., 1., 2., 3., 4.;
+                        0., 0., 0., 6., 5.;
+                        0., 0., 0., 5., 6.];
+
+        let LUP { l, u, p } = PartialPivLu::decompose(b.clone())
+                         .expect("Matrix is well-conditioned.")
+                         .unpack();
+        let k = p.inverse() * l * u;
+
+        assert_matrix_eq!(k, b, comp = float);
+    }
+
+    {
+        let c = matrix![-4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+                        1.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0;
+                        0.0, 1.0, -4.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0;
+                        1.0, 0.0, 0.0, -4.0, 1.0, 0.0, 1.0, 0.0, 0.0;
+                        0.0, 1.0, 0.0, 1.0, -4.0, 1.0, 0.0, 1.0, 0.0;
+                        0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 0.0, 0.0, 1.0;
+                        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -4.0, 1.0, 0.0;
+                        0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0, 1.0;
+                        0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, -4.0];
+
+        let LUP { l, u, p } = PartialPivLu::decompose(c.clone())
+                                .unwrap()
+                                .unpack();
+        let c_reconstructed = p.inverse() * l * u;
+        assert_matrix_eq!(c_reconstructed, c, comp = float);
+    }
+
+    {
+        let d = matrix![1.0, 1.0, 0.0, 0.0;
+                        0.0, 0.0, 1.0, 0.0;
+                        -1.0, 0.0, 0.0, 0.0;
+                        0.0, 0.0, 0.0, 1.0];
+        let LUP { l, u, p } = PartialPivLu::decompose(d.clone())
+                                .unwrap()
+                                .unpack();
+        let d_reconstructed = p.inverse() * l * u;
+        assert_matrix_eq!(d_reconstructed, d, comp = float);
+    }
+}
+
+#[test]
 fn cholesky() {
     let a = matrix![25., 15., -5.;
                     15., 18., 0.;

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -39,6 +39,7 @@ fn test_u_triangular_solve_errs() {
     assert!(a.solve_u_triangular(vector![1.0]).is_err());
 }
 
+#[allow(deprecated)]
 #[test]
 fn matrix_lup_decomp() {
     let a = matrix![1., 3., 5.;


### PR DESCRIPTION
Currently doesn't contain any code pertaining to LU whatsoever, but rather some benchmarks for multiplication of a vector by a permutation matrix. The benchmarks are intended to compare performance between using the new `PermutationMatrix` struct and a full matrix representation of the permutation, and further motivate the use of `PermutationMatrix` in the LU decomposition. I will continue to develop the LU decomposition changes in this PR. Please see #94 for the first (unfinished) draft.

`PermutationMatrix` is implemented such that it can be applied in linear time to a vector, whereas full matrix-vector multiplication is quadratic in the size of the vector. The benchmarks support the expectation that the `PermutationMatrix` approach vastly outperforms the full matrix approach presumably for all `n` (size of the `Vector`).

Because the cost of applying a `PermutationMatrix` is dependent on the specific permutation matrix, there are two kinds of benchmarks: one which applies the identity permutation (which is presumably the cheapest to apply) and one which applies a "perfect shuffle", which one would expect is not overly cache friendly (although perhaps also not the worst example either).

Benchmark results:

```
test linalg::permutation::identity_permutation_as_matrix_mul_vector_100         ... bench:       4,468 ns/iter (+/- 616)
test linalg::permutation::identity_permutation_as_matrix_mul_vector_1000        ... bench:     535,558 ns/iter (+/- 4,675)
test linalg::permutation::identity_permutation_mul_vector_100                   ... bench:         116 ns/iter (+/- 0)
test linalg::permutation::identity_permutation_mul_vector_1000                  ... bench:         866 ns/iter (+/- 2)
test linalg::permutation::perfect_shuffle_permutation_as_matrix_mul_vector_1000 ... bench:     537,161 ns/iter (+/- 15,565)
test linalg::permutation::perfect_shuffle_permutation_mul_vector_1000           ... bench:         847 ns/iter (+/- 4)
```