### PR TITLE
Cholesky decomposition rewrite: initial work

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -11,6 +11,7 @@ pub mod linalg {
 	mod matrix;
 	mod svd;
 	mod lu;
+	mod cholesky;
 	mod norm;
 	mod triangular;
 	mod permutation;

--- a/benches/linalg/cholesky.rs
+++ b/benches/linalg/cholesky.rs
@@ -1,0 +1,49 @@
+use rulinalg::matrix::Matrix;
+use rulinalg::matrix::decomposition::{Cholesky, Decomposition};
+use test::Bencher;
+
+#[bench]
+fn cholesky_decompose_unpack_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        // Assume that the cost of cloning x is roughly
+        // negligible in comparison with the cost of LU
+        Cholesky::decompose(x.clone()).expect("Matrix is invertible")
+                                      .unpack()
+    })
+}
+
+#[bench]
+fn cholesky_decompose_unpack_500x500(b: &mut Bencher) {
+    let n = 500;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        // Assume that the cost of cloning x is roughly
+        // negligible in comparison with the cost of LU
+        Cholesky::decompose(x.clone()).expect("Matrix is invertible")
+                                      .unpack()
+    })
+}
+
+#[bench]
+fn cholesky_100x100(b: &mut Bencher) {
+    // Benchmark for legacy cholesky(). Remove when
+    // cholesky() has been removed.
+    let n = 100;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.cholesky().expect("Matrix is invertible")
+    })
+}
+
+#[bench]
+fn cholesky_500x500(b: &mut Bencher) {
+    // Benchmark for legacy cholesky(). Remove when
+    // cholesky() has been removed.
+    let n = 500;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.cholesky().expect("Matrix is invertible")
+    })
+}

--- a/benches/linalg/cholesky.rs
+++ b/benches/linalg/cholesky.rs
@@ -47,3 +47,23 @@ fn cholesky_500x500(b: &mut Bencher) {
         x.cholesky().expect("Matrix is invertible")
     })
 }
+
+#[bench]
+fn cholesky_solve_1000x1000(b: &mut Bencher) {
+    let n = 1000;
+    let x = Matrix::identity(n);
+    let cholesky = Cholesky::decompose(x).unwrap();
+    b.iter(|| {
+        cholesky.solve(vector![0.0; n])
+    });
+}
+
+#[bench]
+fn cholesky_solve_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = Matrix::identity(n);
+    let cholesky = Cholesky::decompose(x).unwrap();
+    b.iter(|| {
+        cholesky.solve(vector![0.0; n])
+    });
+}

--- a/src/internal_utils.rs
+++ b/src/internal_utils.rs
@@ -1,0 +1,52 @@
+use matrix::BaseMatrixMut;
+use libnum::Zero;
+
+pub fn nullify_lower_triangular_part<T, M>(matrix: &mut M)
+    where T: Zero, M: BaseMatrixMut<T> {
+    for (i, mut row) in matrix.row_iter_mut().enumerate() {
+        for element in row.iter_mut().take(i) {
+            *element = T::zero();
+        }
+    }
+}
+
+pub fn nullify_upper_triangular_part<T, M>(matrix: &mut M)
+    where T: Zero, M: BaseMatrixMut<T> {
+    for (i, mut row) in matrix.row_iter_mut().enumerate() {
+        for element in row.iter_mut().skip(i + 1) {
+            *element = T::zero();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nullify_lower_triangular_part;
+    use super::nullify_upper_triangular_part;
+
+    #[test]
+    fn nullify_lower_triangular_part_examples() {
+        let mut x = matrix![1.0, 2.0, 3.0;
+                            4.0, 5.0, 6.0;
+                            7.0, 8.0, 9.0];
+        nullify_lower_triangular_part(&mut x);
+        assert_matrix_eq!(x, matrix![
+            1.0, 2.0, 3.0;
+            0.0, 5.0, 6.0;
+            0.0, 0.0, 9.0
+        ]);
+    }
+
+    #[test]
+    fn nullify_upper_triangular_part_examples() {
+        let mut x = matrix![1.0, 2.0, 3.0;
+                            4.0, 5.0, 6.0;
+                            7.0, 8.0, 9.0];
+        nullify_upper_triangular_part(&mut x);
+        assert_matrix_eq!(x, matrix![
+            1.0, 0.0, 0.0;
+            4.0, 5.0, 0.0;
+            7.0, 8.0, 9.0
+        ]);
+    }
+}

--- a/src/internal_utils.rs
+++ b/src/internal_utils.rs
@@ -4,7 +4,7 @@ use libnum::Zero;
 pub fn nullify_lower_triangular_part<T, M>(matrix: &mut M)
     where T: Zero, M: BaseMatrixMut<T> {
     for (i, mut row) in matrix.row_iter_mut().enumerate() {
-        for element in row.iter_mut().take(i) {
+        for element in row.raw_slice_mut().iter_mut().take(i) {
             *element = T::zero();
         }
     }
@@ -13,7 +13,7 @@ pub fn nullify_lower_triangular_part<T, M>(matrix: &mut M)
 pub fn nullify_upper_triangular_part<T, M>(matrix: &mut M)
     where T: Zero, M: BaseMatrixMut<T> {
     for (i, mut row) in matrix.row_iter_mut().enumerate() {
-        for element in row.iter_mut().skip(i + 1) {
+        for element in row.raw_slice_mut().iter_mut().skip(i + 1) {
             *element = T::zero();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ pub mod vector;
 pub mod ulp;
 pub mod norm;
 
+mod internal_utils;
+
 #[cfg(test)]
 mod testsupport;
 

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -325,17 +325,12 @@ mod tests {
     #[test]
     fn cholesky_solve_examples() {
         {
-            // TODO: Enable this test
-            // It is currently commented out because
-            // backward/forward substitution don't handle
-            // empty matrices. See PR #152 for more details.
-
-            // let a: Matrix<f64> = matrix![];
-            // let b: Vector<f64> = vector![];
-            // let expected: Vector<f64> = vector![];
-            // let cholesky = Cholesky::decompose(a).unwrap();
-            // let x = cholesky.solve(b);
-            // assert_eq!(x, expected);
+            let a: Matrix<f64> = matrix![];
+            let b: Vector<f64> = vector![];
+            let expected: Vector<f64> = vector![];
+            let cholesky = Cholesky::decompose(a).unwrap();
+            let x = cholesky.solve(b);
+            assert_eq!(x, expected);
         }
 
         {

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -125,7 +125,6 @@ impl<T> Cholesky<T> where T: 'static + Float {
         // the upper triangular part.
         let mut a = matrix;
 
-        // Resolve each submatrix (j .. n, j .. n)
         for j in 0 .. n {
             if j > 0 {
                 // This is essentially a GAXPY operation y = y - Bx

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -169,6 +169,9 @@ impl<T> Cholesky<T> where T: 'static + Float {
     }
 
     /// Computes the determinant of the decomposed matrix.
+    ///
+    /// Note that the determinant of an empty matrix is considered
+    /// to be equal to 1.
     pub fn det(&self) -> T {
         let l_det = self.l.diag()
                           .cloned()

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -70,6 +70,14 @@ impl<T> Cholesky<T> where T: Float {
             l: a
         })
     }
+
+    /// TODO
+    pub fn det(&self) -> T {
+        let l_det = self.l.diag()
+                          .cloned()
+                          .fold(T::one(), |a, b| a * b);
+        l_det * l_det
+    }
 }
 
 impl<T: Zero> Decomposition for Cholesky<T> {
@@ -162,6 +170,7 @@ mod tests {
     use matrix::decomposition::Decomposition;
     use super::Cholesky;
 
+    use libnum::Float;
     use quickcheck::TestResult;
 
     #[test]
@@ -230,6 +239,32 @@ mod tests {
                             3.0,   9.0,  15.0;
                             5.0,  15.0,  65.0];
             assert!(Cholesky::decompose(x).is_err());
+        }
+    }
+
+    #[test]
+    fn cholesky_det_empty() {
+        let x: Matrix<f64> = matrix![];
+        let cholesky = Cholesky::decompose(x).unwrap();
+        assert_eq!(cholesky.det(), 1.0);
+    }
+
+    #[test]
+    fn cholesky_det() {
+        {
+            let x = matrix![1.0];
+            let cholesky = Cholesky::decompose(x).unwrap();
+            let diff = cholesky.det() - 1.0;
+            assert!(diff.abs() < 1e-14);
+        }
+
+        {
+            let x = matrix![1.0,   3.0,   5.0;
+                            3.0,  18.0,  33.0;
+                            5.0,  33.0,  65.0];
+            let cholesky = Cholesky::decompose(x).unwrap();
+            let diff = cholesky.det() - 36.0;
+            assert!(diff.abs() < 1e-14);
         }
     }
 

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -34,7 +34,7 @@ use libnum::{Zero, Float};
 /// with the factor itself. Instead, we may wish to
 /// solve linear systems or compute the determinant or the
 /// inverse of a symmetric positive definite matrix.
-/// In this case, see the next subsections.///
+/// In this case, see the next subsections.
 ///
 /// ```
 /// # #[macro_use] extern crate rulinalg; fn main() {

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -49,7 +49,7 @@ use libnum::{Zero, Float};
 /// let cholesky = Cholesky::decompose(x)
 ///                         .expect("Matrix is SPD.");
 ///
-/// Obtain the matrix factor L
+/// // Obtain the matrix factor L
 /// let l = cholesky.unpack();
 ///
 /// assert_matrix_eq!(l, matrix![1.0,  0.0,  0.0;
@@ -71,7 +71,7 @@ use libnum::{Zero, Float};
 /// # let cholesky = Cholesky::decompose(x).unwrap();
 /// let b1 = vector![ 3.0,  2.0,  1.0];
 /// let b2 = vector![-2.0,  1.0,  0.0];
-/// assert_vector_eq!(cholesky.solve(b1), vector![ 22.00, -7.25,  2.75 ]);
+/// assert_vector_eq!(cholesky.solve(b1), vector![ 23.25, -7.75,  3.0 ]);
 /// assert_vector_eq!(cholesky.solve(b2), vector![-22.25,  7.75, -3.00 ]);
 /// # }
 /// ```

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -97,10 +97,15 @@ impl<T> Cholesky<T> where T: 'static + Float {
     /// Computes the Cholesky decomposition A = L L<sup>T</sup>
     /// for the given square, symmetric positive definite matrix.
     ///
+    /// Note that the implementation cannot reliably and efficiently
+    /// verify that the matrix truly is symmetric positive definite matrix,
+    /// so it is the responsibility of the user to make sure that this is
+    /// the case. In particular, if the input matrix is not SPD,
+    /// the returned decomposition may not be a valid decomposition
+    /// for the input matrix.
+    ///
     /// # Errors
-    /// - A diagonal entry is very close to zero, which
-    ///   corresponds to the matrix being effectively singular
-    ///   to working precision.
+    /// - A diagonal entry is effectively zero to working precision.
     /// - A diagonal entry is negative.
     ///
     /// # Panics

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -237,6 +237,11 @@ impl<T> Matrix<T>
     ///
     /// Returns the cholesky decomposition of a positive definite matrix.
     ///
+    /// *NOTE*: This function is deprecated, and will be removed in a
+    /// future release. Please see
+    /// [Cholesky](decomposition/struct.Cholesky.html) for its
+    /// replacement.
+    ///
     /// # Examples
     ///
     /// ```
@@ -258,6 +263,7 @@ impl<T> Matrix<T>
     /// # Failures
     ///
     /// - Matrix is not positive definite.
+    #[deprecated]
     pub fn cholesky(&self) -> Result<Matrix<T>, Error> {
         assert!(self.rows == self.cols,
                 "Matrix must be square for Cholesky decomposition.");
@@ -352,6 +358,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(deprecated)]
     fn test_non_square_cholesky() {
         let a = Matrix::<f64>::ones(2, 3);
 

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -285,6 +285,9 @@ impl<T> PartialPivLu<T> where T: Any + Float {
     }
 
     /// Computes the determinant of the decomposed matrix.
+    ///
+    /// Note that the determinant of an empty matrix is considered
+    /// to be equal to 1.
     pub fn det(&self) -> T {
         // Recall that the determinant of a triangular matrix
         // is the product of its diagonal entries. Also,

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -135,8 +135,10 @@ impl<T: Clone + One + Zero> Decomposition for PartialPivLu<T> {
     type Factors = LUP<T>;
 
     fn unpack(self) -> LUP<T> {
+        use internal_utils::nullify_lower_triangular_part;
         let l = unit_lower_triangular_part(&self.lu);
-        let u = nullify_lower_triangular_part(self.lu);
+        let mut u = self.lu;
+        nullify_lower_triangular_part(&mut u);
 
         LUP {
             l: l,
@@ -345,15 +347,6 @@ fn unit_lower_triangular_part<T, M>(matrix: &M) -> Matrix<T>
     }
 
     Matrix::new(m, n, data)
-}
-
-fn nullify_lower_triangular_part<T: Zero>(mut matrix: Matrix<T>) -> Matrix<T> {
-    for (i, mut row) in matrix.row_iter_mut().enumerate() {
-        for element in row.iter_mut().take(i) {
-            *element = T::zero();
-        }
-    }
-    matrix
 }
 
 

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -62,14 +62,26 @@
 //! <thead>
 //! <tr>
 //! <th>Decomposition</th>
-//! <th>Applicable to</th>
+//! <th>Matrix requirements</th>
 //! <th>Supported features</th>
 //! </tr>
 //! <tbody>
 //!
 //! <tr>
 //! <td><a href="struct.PartialPivLu.html">PartialPivLu</a></td>
-//! <td>Square, invertible matrices</td>
+//! <td>Square, invertible</td>
+//! <td>
+//!     <ul>
+//!     <li>Linear system solving</li>
+//!     <li>Matrix inverse</li>
+//!     <li>Determinant computation</li>
+//!     </ul>
+//! </td>
+//! </tr>
+//!
+//! <tr>
+//! <td><a href="struct.Cholesky.html">Cholesky</a></td>
+//! <td>Square, symmetric positive definite</td>
 //! <td>
 //!     <ul>
 //!     <li>Linear system solving</li>

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -80,18 +80,6 @@
 //! </tr>
 //!
 //! <tr>
-//! <td><a href="struct.Cholesky.html">Cholesky</a></td>
-//! <td>Square, symmetric positive definite</td>
-//! <td>
-//!     <ul>
-//!     <li>Linear system solving</li>
-//!     <li>Matrix inverse</li>
-//!     <li>Determinant computation</li>
-//!     </ul>
-//! </td>
-//! </tr>
-//!
-//! <tr>
 //! <td><a href="struct.FullPivLu.html">FullPivLu</a></td>
 //! <td>Square matrices</td>
 //! <td>
@@ -100,6 +88,18 @@
 //!     <li>Matrix inverse</li>
 //!     <li>Determinant computation</li>
 //!     <li>Rank computation</li>
+//!     </ul>
+//! </td>
+//! </tr>
+//!
+//! <tr>
+//! <td><a href="struct.Cholesky.html">Cholesky</a></td>
+//! <td>Square, symmetric positive definite</td>
+//! <td>
+//!     <ul>
+//!     <li>Linear system solving</li>
+//!     <li>Matrix inverse</li>
+//!     <li>Determinant computation</li>
 //!     </ul>
 //! </td>
 //! </tr>

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -110,6 +110,7 @@ use utils;
 use error::{Error, ErrorKind};
 
 pub use self::lu::{PartialPivLu, LUP};
+pub use self::cholesky::Cholesky;
 
 use libnum::{Float};
 

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -171,6 +171,7 @@ fn matrix_partial_piv_lu() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn cholesky() {
     let a = matrix![25., 15., -5.;
                     15., 18., 0.;


### PR DESCRIPTION
I started some work on rewriting the Cholesky decomposition in the same style as LU. On the way there, I completely rewrote the algorithm using an algorithm from Golub and Van Loan, which describes the decomposition in terms of GAXPY operations. This meant that I can leverage your efficient `dot` implementation in the `utils` module. The preliminary benchmarks show a significant improvement (`cholesky_nxn` is the existing `cholesky()` implementation): 

```text
test linalg::cholesky::cholesky_100x100                                         ... bench:     201,593 ns/iter (+/- 1,126)
test linalg::cholesky::cholesky_500x500                                         ... bench:  21,765,711 ns/iter (+/- 208,204)
test linalg::cholesky::cholesky_decompose_unpack_100x100                        ... bench:      95,016 ns/iter (+/- 337)
test linalg::cholesky::cholesky_decompose_unpack_500x500                        ... bench:   9,607,424 ns/iter (+/- 535,354)
```

I just thought I'd put this up here, because I think some of this knowledge can also be applied to LU, although the situation is more complicated because of the additional work on `U` as well as the fact that one has to pivot.

**EDIT: Note that this PR includes the entirety of #142! (will rebase after #142 eventually gets merged)**