### PR TITLE
Rewrite forward_substitution and back_substitution

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,5 +1,6 @@
 #![feature(test)]
 
+#[macro_use]
 extern crate rulinalg;
 extern crate num as libnum;
 extern crate test;
@@ -10,4 +11,5 @@ mod linalg {
 	mod matrix;
 	mod svd;
 	mod norm;
+	mod triangular;
 }

--- a/benches/linalg/triangular.rs
+++ b/benches/linalg/triangular.rs
@@ -1,0 +1,58 @@
+use test::Bencher;
+use rulinalg::matrix::Matrix;
+use rulinalg::matrix::BaseMatrix;
+
+#[bench]
+fn solve_l_triangular_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.solve_l_triangular(vector![0.0; n])
+    });
+}
+
+#[bench]
+fn solve_l_triangular_1000x1000(b: &mut Bencher) {
+    let n = 1000;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.solve_l_triangular(vector![0.0; n])
+    });
+}
+
+#[bench]
+fn solve_l_triangular_10000x10000(b: &mut Bencher) {
+    let n = 10000;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.solve_l_triangular(vector![0.0; n])
+    });
+}
+
+#[bench]
+fn solve_u_triangular_100x100(b: &mut Bencher) {
+    let n = 100;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.solve_u_triangular(vector![0.0; n])
+    });
+}
+
+#[bench]
+fn solve_u_triangular_1000x1000(b: &mut Bencher) {
+    let n = 1000;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.solve_u_triangular(vector![0.0; n])
+    });
+}
+
+#[bench]
+fn solve_u_triangular_10000x10000(b: &mut Bencher) {
+    let n = 10000;
+    let x = Matrix::<f64>::identity(n);
+    b.iter(|| {
+        x.solve_u_triangular(vector![0.0; n])
+    });
+}
+

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -7,12 +7,13 @@
 //! via `BaseMatrix` and `BaseMatrixMut` trait.
 
 use std;
-use std::any::Any;
 use std::marker::PhantomData;
 use libnum::Float;
 
 use error::{Error, ErrorKind};
 use vector::Vector;
+
+use utils;
 
 pub mod decomposition;
 mod base;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -296,7 +296,7 @@ pub struct SliceIterMut<'a, T: 'a> {
 /// Here U is an upper triangular matrix and y a vector
 /// which is dimensionally compatible with U.
 fn back_substitution<T, M>(u: &M, y: Vector<T>) -> Result<Vector<T>, Error>
-    where T: Any + Float,
+    where T: Float,
           M: BaseMatrix<T>
 {
     assert!(u.rows() == u.cols(), "Matrix U must be square.");
@@ -341,7 +341,7 @@ fn back_substitution<T, M>(u: &M, y: Vector<T>) -> Result<Vector<T>, Error>
 /// Here, L is a square, lower triangular matrix and y
 /// is a vector which is dimensionally compatible with L.
 fn forward_substitution<T, M>(l: &M, y: Vector<T>) -> Result<Vector<T>, Error>
-    where T: Any + Float,
+    where T: Float,
           M: BaseMatrix<T>
 {
     assert!(l.rows() == l.cols(), "Matrix L must be square.");

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -316,11 +316,11 @@ fn back_substitution<T, M>(u: &M, y: Vector<T>) -> Result<Vector<T>, Error>
         }
 
         // We have
-        // l[i, i] x[i] = b[i] - sum_j { l[i, j] * x[j] }
+        // u[i, i] x[i] = b[i] - sum_j { u[i, j] * x[j] }
         // where j = i + 1, ..., (n - 1)
         //
         // Note that the right-hand side sum term can be rewritten as
-        // l[i, (i + 1) .. n] * x[(i + 1) .. n]
+        // u[i, (i + 1) .. n] * x[(i + 1) .. n]
         // where * denotes the dot product.
         // This is handy, because we have a very efficient
         // dot(., .) implementation!

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -1,4 +1,4 @@
-use rulinalg::matrix::{BaseMatrix, Matrix};
+use rulinalg::matrix::{BaseMatrix};
 
 #[test]
 fn test_solve() {
@@ -33,9 +33,6 @@ fn test_l_triangular_solve_errs() {
 
 #[test]
 fn test_u_triangular_solve_errs() {
-    let a: Matrix<f64> = matrix![];
-    assert!(a.solve_u_triangular(vector![]).is_err());;
-
     let a = matrix![0.0];
     assert!(a.solve_u_triangular(vector![1.0]).is_err());
 }

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -15,17 +15,18 @@ fn test_solve() {
     let b = vector![-100.0, 0.0, 0.0, -100.0, 0.0, 0.0, -100.0, 0.0, 0.0];
 
     let c = a.solve(b).unwrap();
-    let true_solution = vec![42.85714286, 18.75, 7.14285714, 52.67857143,
-                             25.0, 9.82142857, 42.85714286, 18.75, 7.14285714];
+    let true_solution = vector![42.85714286, 18.75, 7.14285714, 52.67857143,
+                                25.0, 9.82142857, 42.85714286, 18.75, 7.14285714];
 
-    assert!(c.into_iter().zip(true_solution.into_iter()).all(|(x, y)| (x-y) < 1e-5));
-
+    // Note: the "true_solution" given here has way too few
+    // significant digits, and since I can't be bothered to enter
+    // it all into e.g. NumPy, I'm leaving a lower absolute
+    // tolerance in place.
+    assert_vector_eq!(c, true_solution, comp = abs, tol = 1e-8);
 }
 
 #[test]
 fn test_l_triangular_solve_errs() {
-    let a: Matrix<f64> = matrix![];
-    assert!(a.solve_l_triangular(vector![]).is_err());
     let a = matrix![0.0];
     assert!(a.solve_l_triangular(vector![1.0]).is_err());
 }


### PR DESCRIPTION
I had some problems with these functions because they returned an error for empty matrices. In my opinion, solving a system `Ax = b` for empty `A` and `b` should merely return an empty `x`. I've had some major grievances in the past with this exact situation with Eigen, which doesn't handle this situation very well. My application generated linear systems from geometrical meshes, and sometimes these systems turned out to be "empty". Graceful handling is thus important so that users don't need to special-case these scenarios.

In any case, I took the liberty to completely rewrite the forward and backward substitution functions. I used some of the techniques I discovered when working on #150 to rewrite them in terms of the highly optimized `utils::dot` function, as well as leveraging our row iterators. They no longer contain any unsafe code, except for needing to call `get_unchecked(i, i)` from `BaseMatrix`. See #151.

The resulting code is significantly simpler, does not allocate a new vector like the previous implementation and is also significantly faster. Here are the benchmarks **before** making the changes:

```text
test linalg::triangular::solve_l_triangular_10000x10000 ... bench:  51,194,669 ns/iter (+/- 323,709)
test linalg::triangular::solve_l_triangular_1000x1000   ... bench:     559,368 ns/iter (+/- 8,496)
test linalg::triangular::solve_l_triangular_100x100     ... bench:       5,394 ns/iter (+/- 550)
test linalg::triangular::solve_u_triangular_10000x10000 ... bench:  50,927,341 ns/iter (+/- 879,902)
test linalg::triangular::solve_u_triangular_1000x1000   ... bench:     550,613 ns/iter (+/- 12,704)
test linalg::triangular::solve_u_triangular_100x100     ... bench:       4,708 ns/iter (+/- 17)
```

Here are the benchmarks **after** making the changes:

```text
test linalg::triangular::solve_l_triangular_10000x10000 ... bench:  29,930,075 ns/iter (+/- 263,948)
test linalg::triangular::solve_l_triangular_1000x1000   ... bench:     296,419 ns/iter (+/- 10,734)
test linalg::triangular::solve_l_triangular_100x100     ... bench:       2,574 ns/iter (+/- 3)
test linalg::triangular::solve_u_triangular_10000x10000 ... bench:  30,100,720 ns/iter (+/- 325,360)
test linalg::triangular::solve_u_triangular_1000x1000   ... bench:     295,012 ns/iter (+/- 3,668)
test linalg::triangular::solve_u_triangular_100x100     ... bench:       3,188 ns/iter (+/- 4)
```