### PR TITLE
Add a new `is_data_contiguous` function #132

### DIFF
--- a/benches/linalg/iter.rs
+++ b/benches/linalg/iter.rs
@@ -57,3 +57,31 @@ fn mat_diag_manual_100_500(b: &mut Bencher) {
         }
     });
 }
+
+#[bench]
+fn mat_contigous_iter_10_50(b: &mut Bencher) {
+
+    let a = Matrix::new(10, 50, vec![2.0;500]);
+    let slice = a.sub_slice([0,0], 10, 50);
+
+    b.iter(|| {
+        for x in slice.iter()
+        {
+            black_box(x);
+        }
+    });
+}
+
+#[bench]
+fn mat_noncontigous_iter_10_50(b: &mut Bencher) {
+
+    let a = Matrix::new(20, 100, vec![2.0;20*100]);
+    let slice = a.sub_slice([0,0], 10, 50);
+
+    b.iter(|| {
+        for x in slice.iter()
+        {
+            black_box(x);
+        }
+    });
+}

--- a/src/matrix/base/impl_base.rs
+++ b/src/matrix/base/impl_base.rs
@@ -76,6 +76,11 @@ impl<T> BaseMatrix<T> for Matrix<T> {
             data: new_data,
         }
     }
+
+    fn is_data_contiguous(&self) -> bool
+    {
+        true
+    }
 }
 
 impl<'a, T> BaseMatrix<T> for MatrixSlice<'a, T> {
@@ -467,5 +472,36 @@ mod tests {
         assert_eq!(a[[2, 1]], c[[1, 2]]);
         assert_eq!(a[[3, 1]], c[[1, 3]]);
         assert_eq!(a[[4, 1]], c[[1, 4]]);
+    }
+
+    #[test]
+    fn is_data_contiguous() {
+        let mut a = matrix![1., 2.;
+                            3., 4.;
+                            5., 6.;
+                            7., 8.;
+                            9., 10.];
+
+        assert!(a.is_data_contiguous());
+
+        {
+            let mut_slice = a.as_mut_slice();
+            assert!(mut_slice.is_data_contiguous());
+        }
+
+        {
+            let mut_slice = a.sub_slice_mut([1,0], 2, 1);
+            assert!(!mut_slice.is_data_contiguous());
+        }
+
+        {
+            let slice = a.as_slice();
+            assert!(slice.is_data_contiguous());
+        }
+
+        {
+            let slice = a.sub_slice([0,1], 3, 1);
+            assert!(!slice.is_data_contiguous());
+        }
     }
 }

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -23,7 +23,7 @@ use matrix::{Matrix, MatrixSlice, MatrixSliceMut};
 use matrix::{Cols, ColsMut, Row, RowMut, Column, ColumnMut, Rows, RowsMut, Axes};
 use matrix::{DiagOffset, Diagonal, DiagonalMut};
 use matrix::{back_substitution, forward_substitution};
-use matrix::{SliceIter, SliceIterMut};
+use matrix::{SliceIter, SliceIterMut, SliceIterIndices};
 use norm::{MatrixNorm, MatrixMetric};
 use vector::Vector;
 use utils;
@@ -200,13 +200,28 @@ pub trait BaseMatrix<T>: Sized {
     fn iter<'a>(&self) -> SliceIter<'a, T>
         where T: 'a
     {
+        let indices =
+            if self.is_data_contiguous()
+            {
+                SliceIterIndices::Contiguous {
+                    index: 0,
+                    slice_size: self.rows() * self.cols(),
+                }
+            }
+            else
+            {
+                SliceIterIndices::NonContiguous {
+                    row_pos: 0,
+                    col_pos: 0,
+                    slice_rows: self.rows(),
+                    slice_cols: self.cols(),
+                    row_stride: self.row_stride(),
+                }
+            };
+
         SliceIter {
             slice_start: self.as_ptr(),
-            row_pos: 0,
-            col_pos: 0,
-            slice_rows: self.rows(),
-            slice_cols: self.cols(),
-            row_stride: self.row_stride(),
+            indices: indices,
             _marker: PhantomData::<&T>,
         }
     }
@@ -1186,13 +1201,28 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
     fn iter_mut<'a>(&mut self) -> SliceIterMut<'a, T>
         where T: 'a
     {
+        let indices =
+            if self.is_data_contiguous()
+            {
+                SliceIterIndices::Contiguous {
+                    index: 0,
+                    slice_size: self.rows() * self.cols(),
+                }
+            }
+            else
+            {
+                SliceIterIndices::NonContiguous {
+                    row_pos: 0,
+                    col_pos: 0,
+                    slice_rows: self.rows(),
+                    slice_cols: self.cols(),
+                    row_stride: self.row_stride(),
+                }
+            };
+
         SliceIterMut {
             slice_start: self.as_mut_ptr(),
-            row_pos: 0,
-            col_pos: 0,
-            slice_rows: self.rows(),
-            slice_cols: self.cols(),
-            row_stride: self.row_stride(),
+            indices: indices,
             _marker: PhantomData::<&mut T>,
         }
     }

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -1113,6 +1113,23 @@ pub trait BaseMatrix<T>: Sized {
                                         self.row_stride())
         }
     }
+    
+    /// Returns whether the matrix elements are stored contiguously in memory.
+    ///
+    /// # Examples
+    /// ```
+    /// use rulinalg::matrix::{Matrix, BaseMatrix, MatrixSlice};
+    ///
+    /// let a = Matrix::new(3, 3, vec![2.0; 9]);
+    /// assert!(a.is_data_contiguous());
+    ///
+    /// let slice = MatrixSlice::from_matrix(&a, [1,1], 2, 2);
+    /// assert!(!slice.is_data_contiguous());
+    /// ```
+    fn is_data_contiguous(&self) -> bool
+    {
+        self.cols() == self.row_stride()
+    }
 }
 
 /// Trait for mutable matrices.

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -281,6 +281,27 @@ pub struct DiagonalMut<'a, T: 'a, M: 'a + BaseMatrixMut<T>> {
     _marker: PhantomData<&'a mut T>,
 }
 
+/// An enum that holds the indices required for the SliceIter and SliceIterMut
+/// structs. These sets depends on whether the underlying data is contiguous 
+/// in memory or not. In the former case, the iter can ignore the matrix 
+/// structure of the data, and simply iterate to the end. In the latter case,
+/// the iter must take into account the row stride.
+#[derive(Debug)]
+enum SliceIterIndices {
+    Contiguous { 
+        index: usize, 
+        slice_size: usize
+     },
+
+    NonContiguous { 
+        row_pos: usize,
+        col_pos: usize,
+        slice_rows: usize,
+        slice_cols: usize,
+        row_stride: usize,
+    }
+}
+
 /// Iterator for matrix.
 ///
 /// Iterates over the underlying slice data
@@ -288,11 +309,7 @@ pub struct DiagonalMut<'a, T: 'a, M: 'a + BaseMatrixMut<T>> {
 #[derive(Debug)]
 pub struct SliceIter<'a, T: 'a> {
     slice_start: *const T,
-    row_pos: usize,
-    col_pos: usize,
-    slice_rows: usize,
-    slice_cols: usize,
-    row_stride: usize,
+    indices: SliceIterIndices,
     _marker: PhantomData<&'a T>,
 }
 
@@ -303,11 +320,7 @@ pub struct SliceIter<'a, T: 'a> {
 #[derive(Debug)]
 pub struct SliceIterMut<'a, T: 'a> {
     slice_start: *mut T,
-    row_pos: usize,
-    col_pos: usize,
-    slice_rows: usize,
-    slice_cols: usize,
-    row_stride: usize,
+    indices: SliceIterIndices,
     _marker: PhantomData<&'a mut T>,
 }
 


### PR DESCRIPTION
This resolves issue #132. It involved adding a new function to the
BaseMatrix trait called `is_data_contiguous` that returns true if the
elements of a matrix are stored contiguously.