### PR TITLE
Fix for documentation on `Matrix::from_fn()`

### DIFF
--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -41,7 +41,7 @@ impl<T> Matrix<T> {
     }
 
     /// Constructor for Matrix struct that takes a function `f`
-    /// and constructs a new matrix such that `A_ij = f(i, j)`,
+    /// and constructs a new matrix such that `A_ij = f(j, i)`,
     /// where `i` is the row index and `j` the column index.
     ///
     /// Requires both the row and column dimensions

--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -67,6 +67,10 @@ impl<T> Matrix<T> {
     ///     2.0, 1.0, 0.0,
     /// ]);
     /// ```
+    /// # Warning
+    ///
+    /// _This function will be changed in a future release so that `A_ij = f(i, j)` - to be consistent
+    /// with the rest of the library._
     pub fn from_fn<F>(rows: usize, cols: usize, mut f: F) -> Matrix<T>
         where F: FnMut(usize, usize) -> T
     {


### PR DESCRIPTION
This one caused me no small amount of grief until I look at the source (although the example is correct).  Ideally, it would be great to change the order of the function arguments from 'col', 'row' to 'row', 'col', but I imagine that would invisibly break a bunch of existing code (I know it would break mine).  You could potentially create a function function like `from_fn2()`, and deprecate the old one, but that's not super great either.