### PR TITLE
Add rectangular matrix support for FullPivLu

### DIFF
--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -51,9 +51,15 @@ pub trait BaseMatrix<T>: Sized {
     /// Row stride in the matrix.
     fn row_stride(&self) -> usize;
 
-    /// Returns true if the matrix contais no elements
+    /// Returns true if the matrix contains no elements
     fn is_empty(&self) -> bool {
         self.rows() == 0 || self.cols() == 0
+    }
+
+    /// Returns true if the matrix has the same number of
+    /// rows as columns.
+    fn is_square(&self) -> bool {
+        self.rows() == self.cols()
     }
 
     /// Top left index of the matrix.

--- a/src/vector/impl_vec.rs
+++ b/src/vector/impl_vec.rs
@@ -67,6 +67,20 @@ impl<T> Vector<T> {
         &self.data
     }
 
+    /// Returns the top `count` rows of the Vector.
+    pub fn top(&self, count: usize) -> Vector<T> where T: Clone {
+        assert!(
+            count <= self.size,
+            "count: {}, self.size: {}",
+            count,
+            self.size);
+
+        Vector {
+            size: count,
+            data: self.data[0..count].to_vec()
+        }
+    }
+
     /// Returns a mutable slice of the underlying data.
     pub fn mut_data(&mut self) -> &mut [T] {
         &mut self.data


### PR DESCRIPTION
This is an attempt to resolve issue #161.

I'm pretty uncertain about the decisions I made in `FullPivLu::solve`. The main problem is that, unlike in `PartialPivLu`, which requires square invertible matrices, `FullPivLu::solve` can now be given a problem that has no solution or has infinitely many solutions. Thoughts on how I went about dealing with this?