### PR TITLE
Fixed (#175) and cleaned up a few tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ mod testsupport;
 extern crate quickcheck;
 
 #[cfg(test)]
-#[macro_use]
 extern crate itertools;
 
 pub use norm::{VectorNorm, MatrixNorm};

--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -369,7 +369,6 @@ mod tests {
     use super::Cholesky;
     use super::transpose_back_substitution;
 
-    use libnum::Float;
     use quickcheck::TestResult;
 
     #[test]
@@ -454,8 +453,7 @@ mod tests {
         {
             let x = matrix![1.0];
             let cholesky = Cholesky::decompose(x).unwrap();
-            let diff = cholesky.det() - 1.0;
-            assert!(diff.abs() < 1e-14);
+            assert_scalar_eq!(cholesky.det(), 1.0, comp = float);
         }
 
         {
@@ -463,8 +461,7 @@ mod tests {
                             3.0,  18.0,  33.0;
                             5.0,  33.0,  65.0];
             let cholesky = Cholesky::decompose(x).unwrap();
-            let diff = cholesky.det() - 36.0;
-            assert!(diff.abs() < 1e-14);
+            assert_scalar_eq!(cholesky.det(), 36.0, comp = float);
         }
     }
 

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -408,9 +408,8 @@ mod tests {
         let v1 = vector![eigenvecs[[0, 0]], eigenvecs[[1, 0]]];
         let v2 = vector![eigenvecs[[0, 1]], eigenvecs[[1, 1]]];
 
-        let epsilon = 0.00001;
-        assert!((&a * &v1 - &v1 * lambda_1).iter().all(|&c| c < epsilon));
-        assert!((&a * &v2 - &v2 * lambda_2).iter().all(|&c| c < epsilon));
+        assert_vector_eq!(&a * &v1, &v1 * lambda_1, comp = float);
+        assert_vector_eq!(&a * &v2, &v2 * lambda_2, comp = float);
     }
 
     #[test]

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -409,8 +409,8 @@ mod tests {
         let v2 = vector![eigenvecs[[0, 1]], eigenvecs[[1, 1]]];
 
         let epsilon = 0.00001;
-        assert!((&a * &v1 - &v1 * lambda_1).into_vec().iter().all(|&c| c < epsilon));
-        assert!((&a * &v2 - &v2 * lambda_2).into_vec().iter().all(|&c| c < epsilon));
+        assert!((&a * &v1 - &v1 * lambda_1).iter().all(|&c| c < epsilon));
+        assert!((&a * &v2 - &v2 * lambda_2).iter().all(|&c| c < epsilon));
     }
 
     #[test]
@@ -419,7 +419,7 @@ mod tests {
                         22., 29., 36.;
                         27., 36., 45.];
 
-        let eigs = a.clone().eigenvalues().unwrap();
+        let eigs = a.eigenvalues().unwrap();
 
         let eig_1 = 90.4026;
         let eig_2 = 0.5973;

--- a/src/matrix/decomposition/lu.rs
+++ b/src/matrix/decomposition/lu.rs
@@ -745,8 +745,6 @@ mod tests {
     use super::{PartialPivLu, LUP, FullPivLu, LUPQ};
     use matrix::decomposition::Decomposition;
 
-    use libnum::Float;
-
     #[allow(deprecated)]
     #[test]
     #[should_panic]
@@ -843,8 +841,7 @@ mod tests {
         let lu = PartialPivLu::decompose(x).unwrap();
 
         let expected_det = 149.99999999999997;
-        let diff = lu.det() - expected_det;
-        assert!(diff.abs() < 1e-12);
+        assert_scalar_eq!(lu.det(), expected_det, comp = float);
     }
 
     #[test]

--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -498,7 +498,6 @@ impl<T: fmt::Display> fmt::Display for Matrix<T> {
 #[cfg(test)]
 mod tests {
     use matrix::{Axes, BaseMatrix, Matrix};
-    use libnum::abs;
 
     #[test]
     fn test_new_mat() {
@@ -668,9 +667,7 @@ mod tests {
 
         let f = e.det();
 
-        println!("det is {0}", f);
-        let error = abs(f - 99.);
-        assert!(error < 1e-10);
+        assert_scalar_eq!(f, 99.0, comp = float);
 
         let g: Matrix<f64> = matrix![1., 2., 3., 4.;
                                      0., 0., 0., 0.;

--- a/src/norm/mod.rs
+++ b/src/norm/mod.rs
@@ -227,14 +227,14 @@ mod tests {
     #[test]
     fn test_euclidean_vector_norm() {
         let v = vector![3.0, 4.0];
-        assert!((VectorNorm::norm(&Euclidean, &v) - 5.0) < 1e-14);
+        assert_scalar_eq!(VectorNorm::norm(&Euclidean, &v), 5.0, comp = float);
     }
 
     #[test]
     fn test_euclidean_matrix_norm() {
         let m = matrix![3.0, 4.0;
                         1.0, 3.0];
-        assert!((MatrixNorm::norm(&Euclidean, &m) - 35.0.sqrt()) < 1e-14);
+        assert_scalar_eq!(MatrixNorm::norm(&Euclidean, &m), 35.0.sqrt(), comp = float);
     }
 
     #[test]
@@ -243,19 +243,19 @@ mod tests {
                         1.0, 3.0];
 
         let slice = MatrixSlice::from_matrix(&m, [0,0], 1, 2);
-        assert!((MatrixNorm::norm(&Euclidean, &slice) - 5.0) < 1e-14);
+        assert_scalar_eq!(MatrixNorm::norm(&Euclidean, &slice), 5.0, comp = float);
     }
 
     #[test]
     fn test_euclidean_vector_metric() {
         let v = vector![3.0, 4.0];
-        assert!((VectorMetric::metric(&Euclidean, &v, &v)) < 1e-14);
+        assert_scalar_eq!(VectorMetric::metric(&Euclidean, &v, &v), 0.0, comp = float);
 
         let v1 = vector![0.0, 0.0];
-        assert!((VectorMetric::metric(&Euclidean, &v, &v1) - 5.0) < 1e-14);
+        assert_scalar_eq!(VectorMetric::metric(&Euclidean, &v, &v1), 5.0, comp = float);
 
         let v2 = vector![4.0, 3.0];
-        assert!((VectorMetric::metric(&Euclidean, &v, &v2) - 2.0.sqrt()) < 1e-14);
+        assert_scalar_eq!(VectorMetric::metric(&Euclidean, &v, &v2), 2.0.sqrt(), comp = float);
     }
 
     #[test]
@@ -271,14 +271,14 @@ mod tests {
     fn test_euclidean_matrix_metric() {
         let m = matrix![3.0, 4.0;
                         1.0, 3.0];
-        assert!((MatrixMetric::metric(&Euclidean, &m, &m)) < 1e-14);
+        assert_scalar_eq!(MatrixMetric::metric(&Euclidean, &m, &m), 0.0, comp = float);
 
         let m1 = Matrix::zeros(2, 2);
-        assert!((MatrixMetric::metric(&Euclidean, &m, &m1) - 35.0.sqrt()) < 1e-14);
+        assert_scalar_eq!(MatrixMetric::metric(&Euclidean, &m, &m1), 35.0.sqrt(), comp = float);
 
         let m2 = matrix![2.0, 3.0;
                          2.0, 4.0];
-        assert!((MatrixMetric::metric(&Euclidean, &m, &m2) - 2.0) < 1e-14);
+        assert_scalar_eq!(MatrixMetric::metric(&Euclidean, &m, &m2), 2.0, comp = float);
     }
 
     #[test]
@@ -312,7 +312,7 @@ mod tests {
             &m2, [0; 2], 1, 2
         );
 
-        assert!(MatrixMetric::metric(&Euclidean, &m_slice, &m2_slice) == 2.0.sqrt());
+        assert_scalar_eq!(MatrixMetric::metric(&Euclidean, &m_slice, &m2_slice), 2.0.sqrt(), comp = exact);
     }
 
     #[test]

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -191,11 +191,7 @@ fn qr() {
                     6., 167., -68.;
                     -4., 24., -41.];
 
-    let res = a.qr_decomp();
-
-    assert!(res.is_ok());
-
-    let (q, r) = res.unwrap();
+    let (q, r) = a.qr_decomp().unwrap();
 
     let true_q = matrix![-0.857143, 0.394286, 0.331429;
                          -0.428571, -0.902857, -0.034286;
@@ -204,10 +200,6 @@ fn qr() {
                          0., -175., 70.;
                          0., 0., -35.];
 
-    for (q_test, q_true) in q.iter().zip(true_q.iter()) {
-        assert_scalar_eq!(q_test, q_true, comp = float, eps = 1e-6);
-    }
-    for (r_test, r_true) in r.iter().zip(true_r.iter()) {
-        assert_scalar_eq!(r_test, r_true, comp = float, eps = 1e-6);
-    }
+    assert_matrix_eq!(q, true_q, comp = abs, tol = 1e-6);
+    assert_matrix_eq!(r, true_r, comp = abs, tol = 1e-6);
 }

--- a/tests/mat/mod.rs
+++ b/tests/mat/mod.rs
@@ -197,8 +197,6 @@ fn qr() {
 
     let (q, r) = res.unwrap();
 
-    let tol = 1e-6;
-
     let true_q = matrix![-0.857143, 0.394286, 0.331429;
                          -0.428571, -0.902857, -0.034286;
                          0.285715, -0.171429, 0.942857];
@@ -206,15 +204,10 @@ fn qr() {
                          0., -175., 70.;
                          0., 0., -35.];
 
-    let q_diff = (q - &true_q).into_vec();
-    let r_diff = (r - &true_r).into_vec();
-
-    for (val, expected) in q_diff.into_iter().zip(true_q.data().iter()) {
-        assert!(val < tol, format!("diff is {0}, expecting {1}", val, expected));
+    for (q_test, q_true) in q.iter().zip(true_q.iter()) {
+        assert_scalar_eq!(q_test, q_true, comp = float, eps = 1e-6);
     }
-
-    for (val, expected) in r_diff.into_iter().zip(true_r.data().iter()) {
-        assert!(val < tol, format!("diff is {0}, expecting {1}", val, expected));
+    for (r_test, r_true) in r.iter().zip(true_r.iter()) {
+        assert_scalar_eq!(r_test, r_true, comp = float, eps = 1e-6);
     }
-
 }


### PR DESCRIPTION
Changed all the easy assert!(diff < eps) to assert_scalar_eq! as I could find

There are still a few instances of a regular diff < eps that can be
found in the src/matrix/decomposition/eigen.rs, but they are inside
iterators that make it harder to easily change.

I also spruced up some of the tests, to remove unneeded clones or things of the sort and removed compiler warnings about unused 'uses'