### PR TITLE
Reworked upper Hessenberg decomposition

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -16,5 +16,6 @@ pub mod linalg {
 	mod norm;
 	mod triangular;
 	mod permutation;
+	mod hessenberg;
 	pub mod util;
 }

--- a/benches/linalg/hessenberg.rs
+++ b/benches/linalg/hessenberg.rs
@@ -1,0 +1,73 @@
+use rulinalg::matrix::decomposition::{Decomposition, HessenbergDecomposition};
+
+use linalg::util::reproducible_random_matrix;
+
+use test::Bencher;
+
+#[bench]
+fn hessenberg_decomposition_decompose_100x100(b: &mut Bencher) {
+    let x = reproducible_random_matrix(100, 100);
+    b.iter(|| {
+        HessenbergDecomposition::decompose(x.clone())
+    })
+}
+
+#[bench]
+fn hessenberg_decomposition_decompose_unpack_100x100(b: &mut Bencher) {
+    let x = reproducible_random_matrix(100, 100);
+    b.iter(|| {
+        HessenbergDecomposition::decompose(x.clone()).unpack()
+    })
+}
+
+#[bench]
+fn hessenberg_decomposition_decompose_200x200(b: &mut Bencher) {
+    let x = reproducible_random_matrix(200, 200);
+    b.iter(|| {
+        HessenbergDecomposition::decompose(x.clone())
+    })
+}
+
+#[bench]
+fn hessenberg_decomposition_decompose_unpack_200x200(b: &mut Bencher) {
+    let x = reproducible_random_matrix(200, 200);
+    b.iter(|| {
+        HessenbergDecomposition::decompose(x.clone()).unpack()
+    })
+}
+
+#[bench]
+#[allow(deprecated)]
+fn upper_hessenberg_100x100(b: &mut Bencher) {
+    let x = reproducible_random_matrix(100, 100);
+    b.iter(|| {
+        x.clone().upper_hessenberg()
+    })
+}
+
+#[bench]
+#[allow(deprecated)]
+fn upper_hess_decomp_100x100(b: &mut Bencher) {
+    let x = reproducible_random_matrix(100, 100);
+    b.iter(|| {
+        x.clone().upper_hess_decomp()
+    })
+}
+
+#[bench]
+#[allow(deprecated)]
+fn upper_hessenberg_200x200(b: &mut Bencher) {
+    let x = reproducible_random_matrix(200, 200);
+    b.iter(|| {
+        x.clone().upper_hessenberg()
+    })
+}
+
+#[bench]
+#[allow(deprecated)]
+fn upper_hess_decomp_200x200(b: &mut Bencher) {
+    let x = reproducible_random_matrix(200, 200);
+    b.iter(|| {
+        x.clone().upper_hess_decomp()
+    })
+}

--- a/src/matrix/decomposition/eigen.rs
+++ b/src/matrix/decomposition/eigen.rs
@@ -82,6 +82,7 @@ impl<T: Any + Float + Signed> Matrix<T> {
                       "Francis shift only works on matrices greater than 2x2.");
         debug_assert!(n == self.cols, "Matrix must be square for Francis shift.");
 
+        #[allow(deprecated)]
         let mut h = try!(self
             .upper_hessenberg()
             .map_err(|_| Error::new(ErrorKind::DecompFailure, "Could not compute eigenvalues.")));
@@ -223,6 +224,7 @@ impl<T: Any + Float + Signed> Matrix<T> {
                       "Francis shift only works on matrices greater than 2x2.");
         debug_assert!(n == self.cols, "Matrix must be square for Francis shift.");
 
+        #[allow(deprecated)]
         let (u, mut h) = try!(self.upper_hess_decomp().map_err(|_| {
             Error::new(ErrorKind::DecompFailure,
                        "Could not compute eigen decomposition.")

--- a/src/matrix/decomposition/hessenberg.rs
+++ b/src/matrix/decomposition/hessenberg.rs
@@ -1,9 +1,171 @@
 use matrix::{Matrix, BaseMatrix, BaseMatrixMut, MatrixSlice, MatrixSliceMut};
+use matrix::decomposition::{Decomposition, HouseholderReflection,
+                            HouseholderComposition};
+use matrix::decomposition::householder;
 use error::{Error, ErrorKind};
+use vector::Vector;
 
 use std::any::Any;
 
-use libnum::{Float};
+use libnum::{Zero, Float};
+
+/// Result of unpacking a
+/// [Hessenberg decomposition](struct.HessenbergDecomposition.html).
+#[derive(Debug, Clone)]
+pub struct QH<T> {
+    /// The orthogonal factor `Q` in the decomposition.
+    pub q: Matrix<T>,
+    /// The upper Hessenberg factor `H` in the decomposition.
+    pub h: Matrix<T>
+}
+
+/// Upper Hessenberg decomposition of real square matrices.
+///
+/// Given any real square `m x m` matrix `A`, there exists an orthogonal
+/// `m x m` matrix `Q` and an `m x m` *upper* Hessenberg matrix `H` such that
+///
+/// ```text
+/// A = Q H Qᵀ.                                         (1)
+/// ```
+///
+/// An Upper Hessenberg matrix `H` is characterized by the property that
+/// `H[i, j] = 0` for any `i > j + 1`. For example, for a 4x4 matrix `H`, this
+/// means that `H` has a the following pattern of zeros and (possibly)
+/// non-zeros `x`:
+///
+/// ```text
+/// [ x x x x ]
+/// [ x x x x ]
+/// [ 0 x x x ]
+/// [ 0 0 x x ]
+/// ```
+///
+/// Hessenberg matrices are of particular interest because their eigenvalues
+/// and eigenvectors can be computed much more efficiently than for a general
+/// non-symmetric matrix, and because the Hessenberg matrix `H` corresponding
+/// to any matrix `A` is unitarily similar to `A`, the eigenvalues of `H`
+/// coincide with the eigenvalues of `A`.
+///
+/// As in the case of [HouseholderQr](struct.HouseholderQr.html),
+/// the `Q` factor is internally stored implicitly in terms of a sequence of
+/// Householder transformations. The implicit `Q` matrix can be accessed by calling
+/// the `.q()` method on the `HessenbergDecomposition` instance.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[macro_use] extern crate rulinalg; fn main() {
+/// use rulinalg::matrix::decomposition::{Decomposition, HessenbergDecomposition, QH};
+///
+/// let x = matrix![5.0, 2.0, 0.0, -2.0;
+///                 3.0, 3.0, 4.0,  3.0;
+///                -3.0, 1.0, 2.0,  1.0;
+///                 2.0, 3.0, 2.0, -3.0];
+///
+/// // We only clone `x` here so that we can compare for equality later
+/// let QH { q, h } = HessenbergDecomposition::decompose(x.clone()).unpack();
+///
+/// assert_matrix_eq!(x, &q * h * q.transpose(), comp = float, ulp = 100);
+/// # }
+/// ```
+///
+/// # Internal storage format
+///
+/// The internal storage format is very similar to that of
+/// [HouseholderQr](struct.HouseholderQr.html). Each Householder reflector
+/// is stored compactly in the elements of the matrix which correspond
+/// to zeros in the Heissenberg factor `H`. In addition, a vector of length
+/// `n - 1` is allocated to hold the multipliers for the Householder vectors.
+#[derive(Debug, Clone)]
+pub struct HessenbergDecomposition<T> {
+    qh: Matrix<T>,
+    tau: Vec<T>
+}
+
+impl<T> HessenbergDecomposition<T> where T: Float {
+    /// Computes the upper Hessenberg decomposition
+    /// for a given square matrix.
+    ///
+    /// # Panics
+    ///
+    /// - The matrix is not square.
+    pub fn decompose(matrix: Matrix<T>) -> HessenbergDecomposition<T> {
+        assert!(matrix.rows() == matrix.cols(), "Matrix must be square for Hessenberg decomposition.");
+        let n = matrix.rows();
+
+        // n - 1 is the number of elements along the sub-1 diagonal
+        // (which characterizes the Hessenberg matrix)
+        let n1 = n.saturating_sub(1);
+
+        let mut qh = matrix;
+        let mut tau = vec![T::zero(); n1];
+
+        let mut buffer = vec![T::zero(); n1];
+        let mut multiply_buffer = vec![T::zero(); n];
+
+        for j in 0 .. n1 {
+            buffer.truncate(n1 - j);
+
+            // Compute the Householder matrix Q_j and left-apply it to the
+            // bottom right corner (we don't need to consider the columns
+            // before j, since they are implicitly zero)
+            let house = {
+                let mut bottom_right = qh.sub_slice_mut([j + 1, j], n1 - j, n - j);
+                bottom_right.col(0).clone_into_slice(&mut buffer);
+
+                let house = HouseholderReflection::compute(Vector::new(buffer));
+                house.buffered_left_multiply_into(&mut bottom_right, &mut multiply_buffer);
+                house.store_in_col(&mut bottom_right.col_mut(0));
+                house
+            };
+
+            // Apply Q_j to the trailing columns
+            let mut trailing_cols = qh.sub_slice_mut([0, j + 1], n, n1 - j);
+            house.buffered_right_multiply_into(&mut trailing_cols, &mut multiply_buffer);
+
+            tau[j] = house.tau();
+            buffer = house.into_vector().into_vec();
+
+        }
+
+        HessenbergDecomposition {
+            qh: qh,
+            tau: tau
+        }
+    }
+
+    /// Returns the orthogonal factor Q as an instance
+    /// of a [HouseholderComposition](struct.HouseholderComposition.html)
+    /// operator.
+    pub fn q(&self) -> HouseholderComposition<T> {
+        householder::create_composition(&self.qh, &self.tau, 1)
+    }
+}
+
+impl<T> Decomposition for HessenbergDecomposition<T> where T: Float {
+    type Factors = QH<T>;
+
+    fn unpack(self) -> Self::Factors {
+        let q = self.q().first_k_columns(self.qh.rows());
+        let mut h = self.qh;
+        nullify_lower_portion(&mut h);
+
+        QH {
+            q: q,
+            h: h
+        }
+    }
+}
+
+/// Makes the portion of the matrix which is not part of the
+/// Upper Hessenberg part identically zero.
+fn nullify_lower_portion<T>(matrix: &mut Matrix<T>) where T: Zero {
+    for (i, mut row) in matrix.row_iter_mut().enumerate().skip(1) {
+        for element in row.raw_slice_mut().iter_mut().take(i - 1) {
+            *element = T::zero();
+        }
+    }
+}
 
 impl<T: Any + Float> Matrix<T> {
     /// Returns H, where H is the upper hessenberg form.
@@ -144,7 +306,12 @@ impl<T: Any + Float> Matrix<T> {
 
 #[cfg(test)]
 mod tests {
-    use matrix::Matrix;
+    use super::QH;
+    use super::HessenbergDecomposition;
+
+    use matrix::{BaseMatrix, Matrix};
+    use matrix::decomposition::Decomposition;
+    use testsupport::is_upper_hessenberg;
 
     #[test]
     #[should_panic]
@@ -161,4 +328,64 @@ mod tests {
 
         let _ = a.upper_hess_decomp();
     }
+
+    fn verify_hessenberg(x: Matrix<f64>) {
+        let QH {ref h, ref q } = HessenbergDecomposition::decompose(x.clone()).unpack();
+
+        assert!(is_upper_hessenberg(h));
+
+        let identity = Matrix::identity(h.rows());
+
+        // Orthogonality. For simplicity, we use a fixed absolute tolerance
+        // and expect elements to be in the vicinity of 1.0
+        assert_matrix_eq!(q.transpose() * q, identity, comp = abs, tol = 1e-14);
+        assert_matrix_eq!(q * q.transpose(), identity, comp = abs, tol = 1e-14);
+
+        // Reconstruction
+        assert_matrix_eq!(q * h * q.transpose(), x, comp = abs, tol = 1e-14);
+    }
+
+    #[test]
+    fn hessenberg_decomposition() {
+        {
+            let x: Matrix<f64> = matrix![];
+            verify_hessenberg(x);
+        }
+
+        {
+            let x = matrix![3.0];
+            verify_hessenberg(x);
+        }
+
+        {
+            let x = matrix![3.0,  2.0;
+                            5.0,  1.0];
+            verify_hessenberg(x);
+        }
+
+        {
+            let x = matrix![3.0,  2.0, -5.0;
+                            5.0,  1.0,  2.0;
+                            3.0, -2.0,  0.0];
+            verify_hessenberg(x);
+        }
+
+        {
+            let x = matrix![3.0,  2.0, -5.0,  2.0;
+                            5.0,  1.0,  2.0, -2.0;
+                            3.0, -2.0,  0.0,  0.0;
+                            4.0,  3.0, -1.0,  3.0];
+            verify_hessenberg(x);
+        }
+
+        {
+            let x = matrix![1.0,  3.0, -5.0,  2.0, 2.0;
+                            0.0,  0.0,  5.0, -1.0, 4.0;
+                            3.0, -4.0,  0.0,  0.0, 5.0;
+                            0.0,  3.0, -1.0,  3.0, 1.0;
+                            2.0, -4.0,  3.0,  2.0, 3.0];
+            verify_hessenberg(x);
+        }
+    }
+
 }

--- a/src/matrix/decomposition/hessenberg.rs
+++ b/src/matrix/decomposition/hessenberg.rs
@@ -173,6 +173,11 @@ impl<T: Any + Float> Matrix<T> {
     /// If the transformation matrix is also required, you should
     /// use `upper_hess_decomp`.
     ///
+    /// Note: This function is deprecated and will be removed in a future
+    /// release. See
+    /// [HessenbergDecomposition](decomposition/struct.HessenbergDecomposition.html)
+    /// for its replacement.
+    ///
     /// # Examples
     ///
     /// ```
@@ -196,6 +201,7 @@ impl<T: Any + Float> Matrix<T> {
     /// # Failures
     ///
     /// - The matrix cannot be reduced to upper hessenberg form.
+    #[deprecated]
     pub fn upper_hessenberg(mut self) -> Result<Matrix<T>, Error> {
         let n = self.rows;
         assert!(n == self.cols,
@@ -249,6 +255,11 @@ impl<T: Any + Float> Matrix<T> {
     ///
     /// Note: The current transform matrix seems broken...
     ///
+    /// Note: This function is deprecated and will be removed in a future
+    /// release. See
+    /// [HessenbergDecomposition](decomposition/struct.HessenbergDecomposition.html)
+    /// for its replacement.
+    ///
     /// # Examples
     ///
     /// ```
@@ -273,6 +284,7 @@ impl<T: Any + Float> Matrix<T> {
     /// # Failures
     ///
     /// - The matrix cannot be reduced to upper hessenberg form.
+    #[deprecated]
     pub fn upper_hess_decomp(self) -> Result<(Matrix<T>, Matrix<T>), Error> {
         let n = self.rows;
         assert!(n == self.cols,
@@ -300,6 +312,7 @@ impl<T: Any + Float> Matrix<T> {
         }
 
         // Now we reduce to upper hessenberg
+        #[allow(deprecated)]
         Ok((transform, try!(self.upper_hessenberg())))
     }
 }
@@ -315,6 +328,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(deprecated)]
     fn test_non_square_upper_hessenberg() {
         let a: Matrix<f64> = Matrix::ones(2, 3);
 
@@ -323,6 +337,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[allow(deprecated)]
     fn test_non_square_upper_hess_decomp() {
         let a: Matrix<f64> = Matrix::ones(2, 3);
 

--- a/src/matrix/decomposition/householder.rs
+++ b/src/matrix/decomposition/householder.rs
@@ -96,12 +96,12 @@ impl<T: Float> HouseholderReflection<T> {
     /// this function computes the product `HA` and stores the result
     /// back in `A`.
     ///
-    /// The user must provide a buffer of size `A.cols()` which is used
+    /// The user must provide a buffer of size at least `A.cols()` which is used
     /// to store intermediate results.
     pub fn buffered_left_multiply_into<M>(&self, matrix: &mut M, buffer: &mut [T])
         where M: BaseMatrixMut<T>
     {
-        assert!(buffer.len() == matrix.cols());
+        assert!(buffer.len() >= matrix.cols());
 
         // Recall that the Householder reflection is represented by
         // H = I - τ v vᵀ,
@@ -120,7 +120,7 @@ impl<T: Float> HouseholderReflection<T> {
         // Instead, we will use the provided buffer to hold the result of the
         // matrix-vector product.
         let ref v = self.v.data();
-        let mut u = buffer;
+        let mut u = &mut buffer[0 .. matrix.cols()];
 
         // u = A^T v
         transpose_gemv(matrix, v, u);
@@ -136,12 +136,12 @@ impl<T: Float> HouseholderReflection<T> {
     /// this function computes the product `AH` and stores the result
     /// back in `A`.
     ///
-    /// The user must provide a buffer of size `A.rows()` which is used
+    /// The user must provide a buffer of size at least `A.rows()` which is used
     /// to store intermediate results.
     pub fn buffered_right_multiply_into<M>(&self, matrix: &mut M, buffer: &mut [T])
         where M: BaseMatrixMut<T>
     {
-        assert!(buffer.len() == matrix.rows());
+        assert!(buffer.len() >= matrix.rows());
 
         // See `buffered_left_multiply_into`. The implementation here
         // is almost exactly the same, except we instead have:
@@ -149,7 +149,7 @@ impl<T: Float> HouseholderReflection<T> {
         // where u = Av.
 
         let ref v = self.v.data();
-        let mut u = buffer;
+        let mut u = &mut buffer[0..matrix.rows()];
 
         // u = A v
         gemv(matrix, v, u);

--- a/src/matrix/decomposition/householder.rs
+++ b/src/matrix/decomposition/householder.rs
@@ -201,8 +201,10 @@ impl<T: Float> HouseholderReflection<T> {
 /// Q = Q_1 * Q_2 * ... * Q_p
 /// ```
 ///
-/// as explained in the documentation for
-/// [HouseholderQr](struct.HouseholderQr.html).
+/// where `p` is the number of transformations. See the
+/// documentation for [HouseholderQr](struct.HouseholderQr.html)
+/// and [HessenbergDecomposition](struct.HessenbergDecomposition.html)
+/// for more details.
 #[derive(Debug, Clone)]
 pub struct HouseholderComposition<'a, T> where T: 'a {
     storage: &'a Matrix<T>,

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -147,6 +147,7 @@ pub use self::householder::HouseholderComposition;
 pub use self::lu::{PartialPivLu, LUP, FullPivLu, LUPQ};
 pub use self::cholesky::Cholesky;
 pub use self::qr::{HouseholderQr, QR, ThinQR};
+pub use self::hessenberg::{HessenbergDecomposition, QH};
 
 use libnum::{Float};
 

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -110,6 +110,12 @@
 //! <td></td>
 //! </tr>
 //!
+//! <tr>
+//! <td><a href="struct.HessenbergDecomposition.html">HessenbergDecomposition</a></td>
+//! <td>Square</td>
+//! <td></td>
+//! </tr>
+//!
 //! </tbody>
 //! </table>
 

--- a/src/matrix/decomposition/qr.rs
+++ b/src/matrix/decomposition/qr.rs
@@ -206,7 +206,7 @@ impl<T> HouseholderQr<T> where T: Float {
             // gets shorter for each iteration, so we truncate the buffer
             // to the appropriate length.
             buffer.truncate(m - j);
-            multiply_buffer.truncate(bottom_right.cols());
+
             bottom_right.col(0).clone_into_slice(&mut buffer);
 
             let house = HouseholderReflection::compute(Vector::new(buffer));

--- a/src/matrix/decomposition/qr.rs
+++ b/src/matrix/decomposition/qr.rs
@@ -226,7 +226,7 @@ impl<T> HouseholderQr<T> where T: Float {
     /// [HouseholderComposition](struct.HouseholderComposition.html)
     /// operator.
     pub fn q(&self) -> HouseholderComposition<T> {
-        householder::create_composition(&self.qr, &self.tau)
+        householder::create_composition(&self.qr, &self.tau, 0)
     }
 
     /// Computes the *thin* (or reduced) QR decomposition.
@@ -264,7 +264,7 @@ impl<T> HouseholderQr<T> where T: Float {
                 r1: qr.r
             }
         } else {
-            let composition = householder::create_composition(&self.qr, &self.tau);
+            let composition = householder::create_composition(&self.qr, &self.tau, 0);
             let q1 = composition.first_k_columns(n);
             let r1 = extract_r1(&self.qr);
             ThinQR {
@@ -291,7 +291,7 @@ impl<T: Float> Decomposition for HouseholderQr<T> {
 
 fn assemble_q<T: Float>(qr: &Matrix<T>, tau: &Vec<T>) -> Matrix<T> {
     let m = qr.rows();
-    let q_operator = householder::create_composition(qr, tau);
+    let q_operator = householder::create_composition(qr, tau, 0);
     q_operator.first_k_columns(m)
 }
 

--- a/src/testsupport/constraints.rs
+++ b/src/testsupport/constraints.rs
@@ -30,10 +30,28 @@ pub fn is_upper_triangular<T, M>(m: &M) -> bool
                         .all(|x| x == &T::zero()))
 }
 
+/// Returns true if the matrix is upper Hessenberg, otherwise false.
+/// Note that if the matrix is not square, it cannot be
+/// upper Hessenberg, and so this function returns false.
+pub fn is_upper_hessenberg<T, M>(m: &M) -> bool
+    where T: Zero + PartialEq<T>, M: BaseMatrix<T>
+{
+    if m.rows() == m.cols() {
+        m.row_iter()
+         .enumerate()
+         .skip(1)
+         .all(|(i, row)| row.iter().take(i - 1)
+                                   .all(|x| x == &T::zero()))
+    } else {
+        false
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::is_lower_triangular;
     use super::is_upper_triangular;
+    use super::is_upper_hessenberg;
     use matrix::Matrix;
 
     #[test]
@@ -122,17 +140,72 @@ mod tests {
         }
     }
 
+    #[test]
+    fn is_upper_hessenberg_valid_input() {
+        {
+            let x: Matrix<u32> = matrix![];
+            assert!(is_upper_hessenberg(&x));
+        }
+
+        {
+            let x = matrix![3];
+            assert!(is_upper_hessenberg(&x));
+        }
+
+        {
+            let x = matrix![3, 2;
+                            4, 0];
+            assert!(is_upper_hessenberg(&x));
+        }
+
+        {
+            let x = matrix![3, 2, 0;
+                            4, 0, 2;
+                            0, 1, 3];
+            assert!(is_upper_hessenberg(&x));
+        }
+
+        {
+            let x = matrix![3, 2, 0, 2;
+                            4, 0, 2, 1;
+                            0, 1, 3, 4;
+                            0, 0, 2, 1];
+            assert!(is_upper_hessenberg(&x));
+        }
+    }
+
+    #[test]
+    fn is_upper_hessenberg_invalid_input() {
+        {
+            let x = matrix![3, 2, 0;
+                            4, 0, 2;
+                            3, 1, 3];
+            assert!(!is_upper_hessenberg(&x));
+        }
+
+        {
+            let x = matrix![3, 2, 0, 5;
+                            4, 0, 2, 2;
+                            3, 1, 3, 1;
+                            0, 3, 2, 0];
+            assert!(!is_upper_hessenberg(&x));
+        }
+    }
+
     quickcheck! {
         fn property_zero_is_lower_triangular(m: usize, n: usize) -> bool {
             let x = Matrix::<u32>::zeros(m, n);
             is_lower_triangular(&x)
         }
-    }
 
-    quickcheck! {
         fn property_zero_is_upper_triangular(m: usize, n: usize) -> bool {
             let x = Matrix::<u32>::zeros(m, n);
             is_upper_triangular(&x)
+        }
+
+        fn property_zero_is_upper_hessenberg(n: usize) -> bool {
+            let x = Matrix::<u32>::zeros(n, n);
+            is_upper_hessenberg(&x)
         }
     }
 }

--- a/src/testsupport/mod.rs
+++ b/src/testsupport/mod.rs
@@ -2,4 +2,5 @@
 //! tests involving data structures provided by rulinalg.
 mod constraints;
 
-pub use self::constraints::{is_lower_triangular, is_upper_triangular};
+pub use self::constraints::{is_lower_triangular, is_upper_triangular,
+                            is_upper_hessenberg};


### PR DESCRIPTION
This PR continues the trend of reworking our decompositions one-by-one. Because the Hessenberg decomposition is very similar to the QR decomposition, we are able to reuse a large amount of functionality. In order to do this, we must extend the concept of `HouseholderComposition` to also allow Householder transformations that operate on the subdiagonal of the matrix rather than the main diagonal (which correspond to QR).

I recommend to look through the commit messages for an overview of how this PR is structured and what changes it makes to existing infrastructure.

Some discussion points

- I've named the decomposition `HessenbergDecomposition`. Would it be sufficient to call it `Hessenberg`? I suppose having `Decomposition` in the name makes it explicitly clear that we are talking about the decomposition. It's strictly speaking an *upper* Hessenberg decomposition, but I've never even heard of anyone using a lower Hessenberg decomposition, so I think this is OK - the decomposition makes it clear that we are talking about an upper Hessenberg decomposition.
- I haven't actually written tests for `HouseholderComposition::left_multiply_into` when `subdiagonal == 1` (corresponding to Hessenberg decomposition). These tests are rather painful to write due to the need for generating test data. The current test only tests for `subdiagonal == 0` (corresponding to QR). However, I think this is OK because the Hessenberg tests verify the correctness of the Hessenberg decomposition, which implicitly depends on the correctness of `left_multiply_into`, as well as `first_k_columns`.

## Performance
Benchmarks show quite considerably increased performance compared to the existing hessenberg routines:

```text
running 8 tests
test linalg::hessenberg::hessenberg_decomposition_decompose_100x100             ... bench:     687,857 ns/iter (+/- 7,512)
test linalg::hessenberg::hessenberg_decomposition_decompose_200x200             ... bench:   5,333,774 ns/iter (+/- 46,163)
test linalg::hessenberg::hessenberg_decomposition_decompose_unpack_100x100      ... bench:     944,946 ns/iter (+/- 6,644)
test linalg::hessenberg::hessenberg_decomposition_decompose_unpack_200x200      ... bench:   7,405,509 ns/iter (+/- 89,003)
test linalg::hessenberg::upper_hess_decomp_100x100                              ... bench:   4,446,958 ns/iter (+/- 71,237)
test linalg::hessenberg::upper_hess_decomp_200x200                              ... bench:  36,832,089 ns/iter (+/- 137,874)
test linalg::hessenberg::upper_hessenberg_100x100                               ... bench:   3,085,405 ns/iter (+/- 45,021)
test linalg::hessenberg::upper_hessenberg_200x200                               ... bench:  25,728,909 ns/iter (+/- 85,632)

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured
```

In the above, `hessenberg_decomposition_*` corresponds to the new functionality. `decompose_NxN` is comparable to the old `upper_hessenberg` function, and `decompose_unpack_NxN` is comparable to the told `upper_hess_decomp` function.
