### PR TITLE
Cholesky: Fix misleading error message

### DIFF
--- a/src/matrix/decomposition/cholesky.rs
+++ b/src/matrix/decomposition/cholesky.rs
@@ -154,7 +154,7 @@ impl<T> Cholesky<T> where T: 'static + Float {
                     "Matrix is singular to working precision."));
             } else if diagonal < T::zero() {
                 return Err(Error::new(ErrorKind::DecompFailure,
-                    "Diagonal entries of matrix are not all positive."));
+                    "Matrix is not positive definite."));
             }
 
             let divisor = diagonal.sqrt();


### PR DESCRIPTION
The diagonals of the *decomposed* matrix were negative, which means the original matrix was not positive definite (even the the diagonal was positive).