### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/macros/matrix.rs
+++ b/src/macros/matrix.rs
@@ -56,8 +56,8 @@ macro_rules! matrix {
             let data_as_nested_array = [ $( [ $($x),* ] ),* ];
             let rows = data_as_nested_array.len();
             let cols = data_as_nested_array[0].len();
-            let data_as_flat_array: Vec<_> = data_as_nested_array.into_iter()
-                .flat_map(|row| row.into_iter())
+            let data_as_flat_array: Vec<_> = data_as_nested_array.iter()
+                .flat_map(|row| row.iter())
                 .cloned()
                 .collect();
             Matrix::new(rows, cols, data_as_flat_array)

--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -1408,7 +1408,7 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
                                                                   isize),
                                                       self.cols());
 
-                for (x, y) in row_a.into_iter().zip(row_b.into_iter()) {
+                for (x, y) in row_a.iter_mut().zip(row_b.iter_mut()) {
                     mem::swap(x, y);
                 }
             }

--- a/src/matrix/decomposition/mod.rs
+++ b/src/matrix/decomposition/mod.rs
@@ -193,7 +193,7 @@ impl<T> Matrix<T>
                                    entry is 0."));
         }
 
-        let mut v = column.into_iter().map(|&x| x / denom).collect::<Vec<T>>();
+        let mut v = column.iter().map(|&x| x / denom).collect::<Vec<T>>();
         // Ensure first element is fixed to 1.
         v[0] = T::one();
         let v = Vector::new(v);
@@ -220,7 +220,7 @@ impl<T> Matrix<T>
                                    entry is 0."));
         }
 
-        let mut v = column.into_iter().map(|&x| x / denom).collect::<Vec<T>>();
+        let mut v = column.iter().map(|&x| x / denom).collect::<Vec<T>>();
         // Ensure first element is fixed to 1.
         v[0] = T::one();
         let v = Matrix::new(size, 1, v);

--- a/src/matrix/impl_mat.rs
+++ b/src/matrix/impl_mat.rs
@@ -134,7 +134,7 @@ impl<T: Clone + Zero> Matrix<T> {
         let size = diag.len();
         let mut data = vec![T::zero(); size * size];
 
-        for (i, item) in diag.into_iter().enumerate().take(size) {
+        for (i, item) in diag.iter().enumerate().take(size) {
             data[i * (size + 1)] = item.clone();
         }
 

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -734,13 +734,13 @@ mod tests {
 
         let mut col_iter = a.col_iter();
 
-        let mut nth0 = col_iter.nth(0).unwrap().into_iter();
+        let mut nth0 = col_iter.nth(0).unwrap().iter();
 
         assert_eq!(0, *nth0.next().unwrap());
         assert_eq!(4, *nth0.next().unwrap());
         assert_eq!(8, *nth0.next().unwrap());
 
-        let mut nth1 = col_iter.nth(2).unwrap().into_iter();
+        let mut nth1 = col_iter.nth(2).unwrap().iter();
 
         assert_eq!(3, *nth1.next().unwrap());
         assert_eq!(7, *nth1.next().unwrap());
@@ -755,7 +755,7 @@ mod tests {
                         4, 5, 6, 7;
                         8, 9, 10, 11];
 
-        let mut col_iter = a.col_iter().last().unwrap().into_iter();
+        let mut col_iter = a.col_iter().last().unwrap().iter();
 
         assert_eq!(3, *col_iter.next().unwrap());
         assert_eq!(7, *col_iter.next().unwrap());
@@ -765,7 +765,7 @@ mod tests {
 
         col_iter.next();
 
-        let mut last_col_iter = col_iter.last().unwrap().into_iter();
+        let mut last_col_iter = col_iter.last().unwrap().iter();
 
         assert_eq!(3, *last_col_iter.next().unwrap());
         assert_eq!(7, *last_col_iter.next().unwrap());

--- a/src/vector/impl_vec.rs
+++ b/src/vector/impl_vec.rs
@@ -250,7 +250,7 @@ impl<T: Copy + PartialOrd> Vector<T> {
     pub fn select(&self, idxs: &[usize]) -> Vector<T> {
         let mut new_data = Vec::with_capacity(idxs.len());
 
-        for idx in idxs.into_iter() {
+        for idx in idxs.iter() {
             new_data.push(self[*idx]);
         }
 


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.