### PR TITLE
Adjust unsafe blocks for the BaseMatrixMut trait

### DIFF
--- a/src/matrix/base/mod.rs
+++ b/src/matrix/base/mod.rs
@@ -616,10 +616,10 @@ pub trait BaseMatrix<T>: Sized {
         }
 
         for row_idx in row_iter.clone() {
-            unsafe {
-                let row = self.row_unchecked(*row_idx);
+            
+                let row = unsafe { self.row_unchecked(*row_idx) };
                 mat_vec.extend_from_slice(row.raw_slice());
-            }
+            
         }
 
         Matrix {
@@ -1398,20 +1398,20 @@ pub trait BaseMatrixMut<T>: BaseMatrix<T> {
                 format!("Row index {0} larger than row count {1}", b, self.rows()));
 
         if a != b {
-            unsafe {
-                let row_a = slice::from_raw_parts_mut(self.as_mut_ptr()
+            
+                let row_a = unsafe { slice::from_raw_parts_mut(self.as_mut_ptr()
                                                           .offset((self.row_stride() * a) as
                                                                   isize),
-                                                      self.cols());
-                let row_b = slice::from_raw_parts_mut(self.as_mut_ptr()
+                                                      self.cols()) };
+                let row_b = unsafe { slice::from_raw_parts_mut(self.as_mut_ptr()
                                                           .offset((self.row_stride() * b) as
                                                                   isize),
-                                                      self.cols());
+                                                      self.cols()) };
 
                 for (x, y) in row_a.into_iter().zip(row_b.into_iter()) {
                     mem::swap(x, y);
                 }
-            }
+            
         }
 
     }

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -16,8 +16,8 @@ impl<'a, T> Iterator for $slice_iter<'a, T> {
         let end = self.slice_rows * self.row_stride;
         // Set the position of the next element
         if offset < end {
-            unsafe {
-                let iter_ptr = self.slice_start.offset(offset as isize);
+            
+                let iter_ptr = unsafe { self.slice_start.offset(offset as isize) };
 
                 // If end of row, set to start of next row
                 if self.col_pos + 1 == self.slice_cols {
@@ -27,8 +27,8 @@ impl<'a, T> Iterator for $slice_iter<'a, T> {
                     self.col_pos += 1usize;
                 }
 
-                Some(mem::transmute(iter_ptr))
-            }
+                Some(unsafe { mem::transmute(iter_ptr) })
+            
         } else {
             None
         }
@@ -119,12 +119,12 @@ impl<'a, T> Iterator for $cols<'a, T> {
         }
 
         let column: $col_type;
-        unsafe {
-            let ptr = self.slice_start.offset(self.col_pos as isize);
+        
+            let ptr = unsafe { self.slice_start.offset(self.col_pos as isize) };
             column  = $col_base {
-                col: $slice_base::from_raw_parts(ptr, self.slice_rows, 1, self.row_stride as usize)
+                col: unsafe { $slice_base::from_raw_parts(ptr, self.slice_rows, 1, self.row_stride as usize) }
             };
-        }
+        
         self.col_pos += 1;
         Some(column)
     }


### PR DESCRIPTION
In this trait you use the unsafe keyword for many safe expressions. However, I found that only 4 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the from_raw_parts_mut()\offset()\mem::transmute() function(these are unsafe functions from the standard library)
2. the row_unchecked() function(row_unchecked() is a native unsafe function)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 